### PR TITLE
Add color function tests

### DIFF
--- a/tests/color.test.js
+++ b/tests/color.test.js
@@ -1,0 +1,21 @@
+// Run tests with:
+//   node tests/color.test.js
+
+const assert = require('assert');
+const { rgbToHsl, hslToRgb } = require('../utils/color');
+
+// Sample RGB triples
+const samples = [
+  [0, 0, 0],
+  [255, 255, 255],
+  [255, 0, 0],
+  [123, 45, 67],
+];
+
+samples.forEach((rgb) => {
+  const hsl = rgbToHsl(...rgb);
+  const result = hslToRgb(...hsl);
+  assert.deepStrictEqual(result, rgb);
+});
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- add `tests` folder with round-trip color tests for utils
- document how to run the tests at the top of `color.test.js`

## Testing
- `node tests/color.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6864404a997083338544d5a556c5963c