### PR TITLE
Improve DOM caching and palette reduction

### DIFF
--- a/filters/reduce.js
+++ b/filters/reduce.js
@@ -18,6 +18,8 @@ const ZX_BASE = [
     for (let bx = 0; bx < blocksX; bx++) {
       // 1. Рахуємо частоти індексів палітри
       const freq = new Array(8).fill(0);
+      const nearest = new Array(64);
+      let p = 0;
       for (let dy = 0; dy < 8; dy++) {
         const y = by * 8 + dy;
         for (let dx = 0; dx < 8; dx++) {
@@ -30,6 +32,7 @@ const ZX_BASE = [
             if (d < minD) { minD = d; minIdx = pi; }
           }
           freq[minIdx]++;
+          nearest[p++] = minIdx;
         }
       }
       // 2. Два найчастіші індекси
@@ -39,17 +42,13 @@ const ZX_BASE = [
       const idxB = top[1]?.idx ?? idxA;
 
       // 3. Для кожного пікселя — приводимо до найближчого індексом:
+      p = 0;
       for (let dy = 0; dy < 8; dy++) {
         const y = by * 8 + dy;
         for (let dx = 0; dx < 8; dx++) {
           const x = bx * 8 + dx;
           const i = (y * w + x) * 4;
-          let minD = Infinity, minIdx = 0;
-          for (let pi = 0; pi < 8; pi++) {
-            const pal = ZX_BASE[pi];
-            const d = (rgba[i] - pal[0])**2 + (rgba[i+1] - pal[1])**2 + (rgba[i+2] - pal[2])**2;
-            if (d < minD) { minD = d; minIdx = pi; }
-          }
+          const minIdx = nearest[p++];
           // ближчий індекс за абсолютною різницею (по колу — якщо потрібно)
           const dToA = Math.abs(minIdx - idxA);
           const dToB = Math.abs(minIdx - idxB);

--- a/main.js
+++ b/main.js
@@ -134,8 +134,8 @@ async function updatePreview() {
     const d = app.activeDocument;
     const docW = Math.round(+d.width),
       docH = Math.round(+d.height);
-    const msg = document.getElementById("msg8");
-    const img = document.getElementById("previewImg");
+
+    // Use cached DOM references
     if (docW % 8 || docH % 8 || docW > 512 || docH > 384) {
       msg.classList.remove("hidden");
       img.src = "";
@@ -150,8 +150,7 @@ async function updatePreview() {
     lastH = thumb.h;
 
     img.src = "data:image/jpeg;base64," + thumb.b64;
-    const sysScale =
-      parseFloat(document.getElementById("sysScaleSel").value) || 1;
+    const sysScale = parseFloat(selSys.value) || 1;
     img.style.width = lastW / sysScale + "px";
     img.style.height = lastH / sysScale + "px";
   } catch (e) {
@@ -258,9 +257,6 @@ action.addNotificationListener(["make", "set", "delete"], () =>
 
 // Ensure DOM is ready before binding UI
 document.addEventListener("DOMContentLoaded", () => {
-  // Get UI elements
-  const img = document.getElementById("previewImg");
-  const msg = document.getElementById("msg8");
 
   setupControls({
     zxFilter,


### PR DESCRIPTION
## Summary
- cache DOM references instead of querying every preview update
- avoid repeated nearest-color computations in `reduceToDominantPair`

## Testing
- `node tests/color.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686a7ea32788833396c1b640c1c94c31