### PR TITLE
Add bright mode state initialization

### DIFF
--- a/main.js
+++ b/main.js
@@ -36,6 +36,13 @@ let selectedAlg = (function() {
 })();
 let ditherT = 0.5;
 
+// Initialize brightMode from saved settings or default to "on"
+let brightMode = (function() {
+  const settings = (typeof loadSettings === 'function') ? loadSettings() : {};
+  if (settings && settings.brightMode) return settings.brightMode;
+  return 'on';
+})();
+
 // ZX Spectrum “Primary” palette (8 base + bright variants)
 const ZX_BASE = [
   [0, 0, 0],


### PR DESCRIPTION
## Summary
- initialize `brightMode` state from saved settings or default to `'on'`
- keep `setBrightMode` function to update this state

## Testing
- `node tests/color.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686a94b502088333a4bcbc63b51ab7a5