### PR TITLE
Introduce indexed color pipeline

### DIFF
--- a/tests/indexed.test.js
+++ b/tests/indexed.test.js
@@ -1,0 +1,127 @@
+// tests/indexed.test.js
+// Run with: node tests/indexed.test.js
+
+const assert = require('assert');
+const { rgbaToIndexed, indexedToRgba, ZX_BASE } = require('../utils/indexed');
+
+// simple old encoder copied from previous implementation
+function oldEncodeScr(rgba, W, H, bright) {
+  function mapPalIndex(rgb) {
+    const ZX_PALETTE = [];
+    for (let i = 0; i < 8; i++) ZX_PALETTE.push({ rgb: ZX_BASE[i], bright: false });
+    for (let i = 1; i < 8; i++) {
+      const [r, g, b] = ZX_BASE[i].map(v => (v === 0 ? 0 : 255));
+      ZX_PALETTE.push({ rgb: [r, g, b], bright: true });
+    }
+    let best = 0, bd = Infinity;
+    ZX_PALETTE.forEach((p,i) => {
+      const dr = p.rgb[0]-rgb[0];
+      const dg = p.rgb[1]-rgb[1];
+      const db = p.rgb[2]-rgb[2];
+      const d = dr*dr + dg*dg + db*db;
+      if (d < bd) { bd = d; best = i; }
+    });
+    return best;
+  }
+  const scrBytes = new Uint8Array(6912);
+  scrBytes.fill(0);
+  const cols = W >> 3, rows = H >> 3;
+  for (let by=0; by<rows; by++) {
+    for (let bx=0; bx<cols; bx++) {
+      const freq = new Map();
+      for (let dy=0; dy<8; dy++) {
+        const y = by*8 + dy;
+        for (let dx=0; dx<8; dx++) {
+          const x = bx*8 + dx;
+          const i4 = (y*W + x)*4;
+          const key = `${rgba[i4]},${rgba[i4+1]},${rgba[i4+2]}`;
+          freq.set(key, (freq.get(key)||0)+1);
+        }
+      }
+      const sorted = [...freq.entries()].sort((a,b)=>b[1]-a[1]);
+      const inkRgb = sorted[0][0].split(',').map(Number);
+      const paperRgb = (sorted[1]||sorted[0])[0].split(',').map(Number);
+      for (let dy=0; dy<8; dy++) {
+        const y = by*8 + dy;
+        const bankOffset = (y & 0xC0) << 5;
+        const rowOffset  = (y & 0x38) << 2;
+        const lineOffset = (y & 0x07) << 8;
+        const baseAddr   = bankOffset | rowOffset | lineOffset | bx;
+        let byte = 0;
+        for (let bit=0; bit<8; bit++) {
+          const x = bx*8 + bit;
+          const i4 = (y*W + x)*4;
+          const matchInk = rgba[i4]===inkRgb[0] && rgba[i4+1]===inkRgb[1] && rgba[i4+2]===inkRgb[2];
+          byte |= (matchInk?1:0) << (7-bit);
+        }
+        scrBytes[baseAddr] = byte;
+      }
+      const rawInkIdx = mapPalIndex(inkRgb);
+      const rawPaperIdx = mapPalIndex(paperRgb);
+      const inkIdx = rawInkIdx<8 ? rawInkIdx : rawInkIdx-7;
+      const paperIdx = rawPaperIdx<8 ? rawPaperIdx : rawPaperIdx-7;
+      const attrAddr = 6144 + by*cols + bx;
+      scrBytes[attrAddr] = ((bright?1:0)<<6)|((paperIdx&7)<<3)|(inkIdx&7);
+    }
+  }
+  return scrBytes;
+}
+
+function newEncodeScr(indexed) {
+  const { pixels, attrs, width:W, height:H } = indexed;
+  const scrBytes = new Uint8Array(6912);
+  scrBytes.fill(0);
+  const cols = W>>3, rows=H>>3;
+  for (let by=0; by<rows; by++) {
+    for (let bx=0; bx<cols; bx++) {
+      const attr = attrs[by*cols+bx];
+      for (let dy=0; dy<8; dy++) {
+        const y=by*8+dy;
+        const bankOffset=(y & 0xC0)<<5;
+        const rowOffset=(y & 0x38)<<2;
+        const lineOffset=(y & 0x07)<<8;
+        const baseAddr=bankOffset|rowOffset|lineOffset|bx;
+        let byte=0;
+        for (let bit=0; bit<8; bit++) {
+          const x=bx*8+bit;
+          const idx=pixels[y*W + x];
+          byte |= (idx===attr.ink?1:0)<<(7-bit);
+        }
+        scrBytes[baseAddr]=byte;
+      }
+      const attrAddr=6144+by*cols+bx;
+      scrBytes[attrAddr]=((attr.flash?1:0)<<7)|((attr.bright?1:0)<<6)|((attr.paper&7)<<3)|(attr.ink&7);
+    }
+  }
+  return scrBytes;
+}
+
+// create simple 16x16 test pattern
+const W=16, H=16;
+const rgba = new Uint8Array(W*H*4);
+function fillBlock(bx,by,cA,cB){
+  for(let dy=0; dy<8; dy++){
+    for(let dx=0; dx<8; dx++){
+      const idx=dx<5?cA:cB;
+      const [r,g,b]=ZX_BASE[idx];
+      const x=bx*8+dx;
+      const y=by*8+dy;
+      const p=(y*W+x)*4;
+      rgba[p]=r; rgba[p+1]=g; rgba[p+2]=b; rgba[p+3]=255;
+    }
+  }
+}
+fillBlock(0,0,0,2);
+fillBlock(1,0,1,3);
+fillBlock(0,1,4,6);
+fillBlock(1,1,5,7);
+
+const indexed = rgbaToIndexed(rgba, W, H, { bright: 0, flash: 0 });
+const roundtrip = indexedToRgba(indexed);
+assert.deepStrictEqual(Array.from(roundtrip), Array.from(rgba));
+
+const oldScr = oldEncodeScr(rgba, W, H, 0);
+const newScr = newEncodeScr(indexed);
+assert.deepStrictEqual(Array.from(newScr), Array.from(oldScr));
+
+console.log('Indexed conversion tests passed');

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -1,6 +1,7 @@
 // src/ui/controls.js
 const { app, imaging, core } = require("photoshop");
 const { getRgbaPixels } = require("../utils/utils");
+const { indexedToRgba } = require("../utils/indexed");
 
 function getDomElements() {
   return {
@@ -165,8 +166,9 @@ function setupControls({
         // Отримуємо RGBA через утиліту
         const { rgba } = await getRgbaPixels(imaging, { left: 0, top: 0, width: W, height: H }, true);
         // Застосовуємо фільтр ZX
-        zxFilter(rgba, W, H);
-        const newData = await imaging.createImageDataFromBuffer(rgba, {
+        const indexed = zxFilter(rgba, W, H);
+        const outRgba = indexedToRgba(indexed);
+        const newData = await imaging.createImageDataFromBuffer(outRgba, {
           width: W,
           height: H,
           components: 4,

--- a/utils/indexed.js
+++ b/utils/indexed.js
@@ -1,0 +1,80 @@
+// utils/indexed.js
+// Conversion between RGBA buffers and ZX Spectrum indexed representation
+
+const ZX_BASE = [
+  [0, 0, 0],
+  [0, 0, 192],
+  [192, 0, 0],
+  [192, 0, 192],
+  [0, 192, 0],
+  [0, 192, 192],
+  [192, 192, 0],
+  [192, 192, 192],
+];
+
+function rgbToIndex(r, g, b) {
+  const rBit = r >= 128 ? 1 : 0;
+  const gBit = g >= 128 ? 1 : 0;
+  const bBit = b >= 128 ? 1 : 0;
+  return (gBit << 2) | (rBit << 1) | bBit;
+}
+
+function rgbaToIndexed(rgba, w, h, opts = {}) {
+  const { bright = 0, flash = 0 } = opts;
+  const pixels = new Uint8Array(w * h);
+  const cols = w >> 3;
+  const rows = h >> 3;
+  const attrs = new Array(cols * rows);
+  let a = 0;
+  for (let by = 0; by < rows; by++) {
+    for (let bx = 0; bx < cols; bx++) {
+      const freq = new Array(8).fill(0);
+      for (let dy = 0; dy < 8; dy++) {
+        const y = by * 8 + dy;
+        for (let dx = 0; dx < 8; dx++) {
+          const x = bx * 8 + dx;
+          const i4 = (y * w + x) * 4;
+          const idx = rgbToIndex(rgba[i4], rgba[i4 + 1], rgba[i4 + 2]);
+          pixels[y * w + x] = idx;
+          freq[idx]++;
+        }
+      }
+      const top = freq.map((count, idx) => ({ count, idx }))
+        .sort((a, b) => b.count - a.count);
+      const ink = top[0].idx;
+      const paper = (top[1] ? top[1].idx : ink);
+      attrs[a++] = { ink, paper, bright, flash };
+    }
+  }
+  return { pixels, attrs, width: w, height: h };
+}
+
+function indexToRgb(idx, bright) {
+  const base = ZX_BASE[idx];
+  if (bright && idx) {
+    return base.map(v => (v === 0 ? 0 : 255));
+  }
+  return base;
+}
+
+function indexedToRgba({ pixels, attrs, width: w, height: h }) {
+  const rgba = new Uint8Array(w * h * 4);
+  const cols = w >> 3;
+  for (let y = 0; y < h; y++) {
+    const by = y >> 3;
+    for (let x = 0; x < w; x++) {
+      const bx = x >> 3;
+      const attr = attrs[by * cols + bx];
+      const idx = pixels[y * w + x];
+      const [r, g, b] = indexToRgb(idx, attr.bright);
+      const p = (y * w + x) * 4;
+      rgba[p] = r;
+      rgba[p + 1] = g;
+      rgba[p + 2] = b;
+      rgba[p + 3] = 255;
+    }
+  }
+  return rgba;
+}
+
+module.exports = { rgbaToIndexed, indexedToRgba, ZX_BASE };


### PR DESCRIPTION
## Summary
- add a new `utils/indexed.js` module
- change `zxFilter` to output indexed pixels and attributes
- convert indexed data back to RGBA for previews
- rewrite `saveSCR` to use indexed representation
- update UI apply logic to work with new structure
- add tests for indexed conversion round‐trip
- refine mapping so index conversion only looks at 3-bit base colors

## Testing
- `node tests/color.test.js`
- `node tests/indexed.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686a94e819b88333b7f5fea89cef57e1