### PR TITLE
Implement auto-bright detection

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ const { setupControls, loadSettings } = require("./ui/controls");
 const { reduceToDominantPair } = require("./filters/reduce");
 const { saturate100 } = require("./filters/saturate");
 const { ditherSeparateChannels } = require("./filters/dither");
-const { rgbaToIndexed, indexedToRgba } = require("./utils/indexed");
+const { rgbaToIndexed, indexedToRgba, computeBrightAttrs } = require("./utils/indexed");
 const { storage } = require("uxp");
 const fs = storage.localFileSystem;
 const formats = storage.formats;
@@ -86,10 +86,15 @@ function setBrightMode(v) {
 
 // Core filter
 function zxFilter(rgba, w, h) {
+  let brightBits;
+  if (brightMode === "auto") {
+    const orig = new Uint8Array(rgba);
+    brightBits = computeBrightAttrs(orig, w, h);
+  }
   ditherSeparateChannels(rgba, w, h, selectedAlg, ditherT);
   reduceToDominantPair(rgba, w, h);
   const bright = brightMode === "on" ? 1 : 0;
-  return rgbaToIndexed(rgba, w, h, { bright, flash: 0 });
+  return rgbaToIndexed(rgba, w, h, { bright, flash: 0, brightBits });
 }
 
 async function fetchThumb() {

--- a/tests/bright.test.js
+++ b/tests/bright.test.js
@@ -1,0 +1,44 @@
+// tests/bright.test.js
+// Run with: node tests/bright.test.js
+
+const assert = require('assert');
+const { rgbaToIndexed, indexedToRgba, computeBrightAttrs, ZX_BASE } = require('../utils/indexed');
+
+const W = 16, H = 8; // two blocks horizontally
+const rgba = new Uint8Array(W * H * 4);
+
+// block 0: half bright blue, half black
+for (let y = 0; y < 8; y++) {
+  for (let x = 0; x < 8; x++) {
+    const p = (y * W + x) * 4;
+    if (x < 4) { // bright blue
+      rgba[p] = 0; rgba[p+1] = 0; rgba[p+2] = 255; rgba[p+3] = 255;
+    } else { // black
+      rgba[p] = 0; rgba[p+1] = 0; rgba[p+2] = 0; rgba[p+3] = 255;
+    }
+  }
+}
+
+// block 1: fully black
+for (let y = 0; y < 8; y++) {
+  for (let x = 8; x < 16; x++) {
+    const p = (y * W + x) * 4;
+    rgba[p] = 0; rgba[p+1] = 0; rgba[p+2] = 0; rgba[p+3] = 255;
+  }
+}
+
+const bits = computeBrightAttrs(rgba, W, H);
+assert.strictEqual(bits.length, 2);
+assert.strictEqual(bits[0], 1); // bright due to blue
+assert.strictEqual(bits[1], 1); // inherits majority brightness
+
+const indexed = rgbaToIndexed(rgba, W, H, { brightBits: bits, flash: 0, bright: 0 });
+
+assert.strictEqual(indexed.attrs[0].bright, 1);
+assert.strictEqual(indexed.attrs[1].bright, 1);
+
+const round = indexedToRgba(indexed);
+assert.strictEqual(round.length, rgba.length);
+
+console.log('Auto-bright tests passed');
+

--- a/utils/indexed.js
+++ b/utils/indexed.js
@@ -12,6 +12,14 @@ const ZX_BASE = [
   [192, 192, 192],
 ];
 
+// Helper palette including bright variants (skip bright black)
+const ZX_FULL = [];
+for (let i = 0; i < 8; i++) ZX_FULL.push({ rgb: ZX_BASE[i], bright: false });
+for (let i = 1; i < 8; i++) {
+  const [r, g, b] = ZX_BASE[i].map(v => (v === 0 ? 0 : 255));
+  ZX_FULL.push({ rgb: [r, g, b], bright: true });
+}
+
 function rgbToIndex(r, g, b) {
   const rBit = r >= 128 ? 1 : 0;
   const gBit = g >= 128 ? 1 : 0;
@@ -19,8 +27,63 @@ function rgbToIndex(r, g, b) {
   return (gBit << 2) | (rBit << 1) | bBit;
 }
 
+function computeBrightAttrs(rgba, w, h) {
+  const cols = w >> 3;
+  const rows = h >> 3;
+  const bits = new Uint8Array(cols * rows);
+  const blackBuf = [];
+  let brightBlocks = 0;
+  let darkBlocks = 0;
+  for (let by = 0; by < rows; by++) {
+    for (let bx = 0; bx < cols; bx++) {
+      const freq = new Array(ZX_FULL.length).fill(0);
+      for (let dy = 0; dy < 8; dy++) {
+        const y = by * 8 + dy;
+        for (let dx = 0; dx < 8; dx++) {
+          const x = bx * 8 + dx;
+          const p = (y * w + x) * 4;
+          const r = rgba[p];
+          const g = rgba[p + 1];
+          const b = rgba[p + 2];
+          let best = 0;
+          let bd = Infinity;
+          for (let i = 0; i < ZX_FULL.length; i++) {
+            const pr = ZX_FULL[i].rgb[0];
+            const pg = ZX_FULL[i].rgb[1];
+            const pb = ZX_FULL[i].rgb[2];
+            const d = (pr - r) * (pr - r) + (pg - g) * (pg - g) + (pb - b) * (pb - b);
+            if (d < bd) { bd = d; best = i; }
+          }
+          freq[best]++;
+        }
+      }
+      const sorted = freq.map((c, i) => ({ c, i })).sort((a, b) => b.c - a.c);
+      const idxA = sorted[0].i;
+      const idxB = sorted[1] ? sorted[1].i : idxA;
+      const bi = by * cols + bx;
+      if (idxA === 0 && freq[idxA] === 64) {
+        blackBuf.push(bi);
+        continue;
+      }
+      const pair = [ { idx: idxA, count: freq[idxA] }, { idx: idxB, count: freq[idxB] } ];
+      let brightScore = 0;
+      let darkScore = 0;
+      for (const { idx, count } of pair) {
+        if (idx === 0) continue; // ignore black
+        if (ZX_FULL[idx].bright) brightScore += count; else darkScore += count;
+      }
+      const bit = brightScore >= darkScore ? 1 : 0;
+      bits[bi] = bit;
+      if (bit) brightBlocks++; else darkBlocks++;
+    }
+  }
+  const majority = (brightBlocks + darkBlocks) ? (brightBlocks >= darkBlocks ? 1 : 0) : 0;
+  for (const bi of blackBuf) bits[bi] = majority;
+  return bits;
+}
+
 function rgbaToIndexed(rgba, w, h, opts = {}) {
-  const { bright = 0, flash = 0 } = opts;
+  const { bright = 0, flash = 0, brightBits = null } = opts;
   const pixels = new Uint8Array(w * h);
   const cols = w >> 3;
   const rows = h >> 3;
@@ -43,7 +106,8 @@ function rgbaToIndexed(rgba, w, h, opts = {}) {
         .sort((a, b) => b.count - a.count);
       const ink = top[0].idx;
       const paper = (top[1] ? top[1].idx : ink);
-      attrs[a++] = { ink, paper, bright, flash };
+      const blockBright = brightBits ? brightBits[a] : bright;
+      attrs[a++] = { ink, paper, bright: blockBright, flash };
     }
   }
   return { pixels, attrs, width: w, height: h };
@@ -77,4 +141,4 @@ function indexedToRgba({ pixels, attrs, width: w, height: h }) {
   return rgba;
 }
 
-module.exports = { rgbaToIndexed, indexedToRgba, ZX_BASE };
+module.exports = { rgbaToIndexed, indexedToRgba, computeBrightAttrs, ZX_BASE };


### PR DESCRIPTION
## Summary
- detect `brightMode === 'auto'` in `zxFilter`
- add `computeBrightAttrs` helper and expose through `utils/indexed.js`
- extend `rgbaToIndexed` to accept per-block brightness
- use new helper in `zxFilter`
- test automatic brightness detection

## Testing
- `node tests/color.test.js && node tests/indexed.test.js && node tests/bright.test.js`

------
https://chatgpt.com/codex/tasks/task_e_686ba00dd49c8333a1153bb02dcdc588