### PR TITLE
Add SCR tiling export and tests

### DIFF
--- a/tests/scr.test.js
+++ b/tests/scr.test.js
@@ -1,0 +1,105 @@
+// tests/scr.test.js
+// Run with: node tests/scr.test.js
+
+const assert = require('assert');
+const { encodeTiles } = require('../utils/scr');
+
+function makeIndexed(W, H, ink = 1, paper = 0) {
+  const pixels = new Uint8Array(W * H);
+  pixels.fill(ink);
+  const cols = Math.ceil(W / 8);
+  const rows = Math.ceil(H / 8);
+  const attrs = new Array(cols * rows).fill(0).map(() => ({ ink, paper, bright: 0, flash: 0 }));
+  return { pixels, attrs, width: W, height: H };
+}
+
+function decode(scr) {
+  const pixels = new Uint8Array(256 * 192);
+  for (let y = 0; y < 192; y++) {
+    for (let xb = 0; xb < 32; xb++) {
+      const addr = ((y & 0xC0) << 5) | ((y & 0x38) << 2) | ((y & 0x07) << 8) | xb;
+      const byte = scr[addr];
+      for (let bit = 0; bit < 8; bit++) {
+        const x = xb * 8 + bit;
+        pixels[y * 256 + x] = (byte >> (7 - bit)) & 1;
+      }
+    }
+  }
+  const attrs = new Uint8Array(32 * 24);
+  for (let by = 0; by < 24; by++) {
+    for (let bx = 0; bx < 32; bx++) {
+      attrs[by * 32 + bx] = scr[6144 + by * 32 + bx];
+    }
+  }
+  return { pixels, attrs };
+}
+
+// Case 1: 64x64
+(() => {
+  const idx = makeIndexed(64, 64);
+  const tiles = encodeTiles(idx);
+  assert.strictEqual(tiles.length, 1);
+  const d = decode(tiles[0].bytes);
+  for (let y = 0; y < 192; y++) {
+    for (let x = 0; x < 256; x++) {
+      const val = d.pixels[y * 256 + x];
+      if (y < 64 && x < 64) assert.strictEqual(val, 1);
+      else assert.strictEqual(val, 0);
+    }
+  }
+  for (let by = 0; by < 24; by++) {
+    for (let bx = 0; bx < 32; bx++) {
+      const a = d.attrs[by * 32 + bx];
+      if (by < 8 && bx < 8) assert.strictEqual(a, 1);
+      else assert.strictEqual(a, 7);
+    }
+  }
+})();
+
+// Case 2: exactly 256x192
+(() => {
+  const idx = makeIndexed(256, 192, 2);
+  const tiles = encodeTiles(idx);
+  assert.strictEqual(tiles.length, 1);
+  const d = decode(tiles[0].bytes);
+  for (const v of d.pixels) assert.strictEqual(v, 1);
+  for (const a of d.attrs) assert.strictEqual(a, 2);
+})();
+
+// Case 3: 512x64 -> two tiles
+(() => {
+  const idx = makeIndexed(512, 64);
+  const tiles = encodeTiles(idx);
+  assert.strictEqual(tiles.length, 2);
+  tiles.forEach((t, i) => {
+    const d = decode(t.bytes);
+    for (let y = 0; y < 192; y++) {
+      for (let x = 0; x < 256; x++) {
+        const val = d.pixels[y * 256 + x];
+        if (y < 64) assert.strictEqual(val, 1);
+        else assert.strictEqual(val, 0);
+      }
+    }
+  });
+})();
+
+// Case 4: 300x200 -> four tiles
+(() => {
+  const idx = makeIndexed(300, 200);
+  const tiles = encodeTiles(idx);
+  assert.strictEqual(tiles.length, 4);
+  tiles.forEach(t => {
+    const d = decode(t.bytes);
+    for (let y = 0; y < 192; y++) {
+      for (let x = 0; x < 256; x++) {
+        const inDocX = t.tx * 256 + x < 300;
+        const inDocY = t.ty * 192 + y < 200;
+        const val = d.pixels[y * 256 + x];
+        if (inDocX && inDocY) assert.strictEqual(val, 1);
+        else assert.strictEqual(val, 0);
+      }
+    }
+  });
+})();
+
+console.log('SCR tiling tests passed');

--- a/utils/scr.js
+++ b/utils/scr.js
@@ -1,0 +1,61 @@
+// utils/scr.js
+// Encoding ZX Spectrum SCR files with tiling support
+
+function encodeTile(indexed, tx = 0, ty = 0) {
+  const { pixels, attrs, width: W, height: H } = indexed;
+  const wBlocks = Math.ceil(W / 8);
+  const hBlocks = Math.ceil(H / 8);
+  const scr = new Uint8Array(6912);
+  scr.fill(0);
+  const defaultAttr = 7; // INK=7, PAPER=0, BRIGHT=0, FLASH=0
+  scr.fill(defaultAttr, 6144);
+
+  const startBx = tx * 32;
+  const startBy = ty * 24;
+  const cols = Math.min(32, wBlocks - startBx);
+  const rows = Math.min(24, hBlocks - startBy);
+
+  for (let by = 0; by < rows; by++) {
+    for (let bx = 0; bx < cols; bx++) {
+      const aIdx = (startBy + by) * wBlocks + (startBx + bx);
+      const attr = attrs[aIdx] || { ink: 7, paper: 0, bright: 0, flash: 0 };
+      for (let dy = 0; dy < 8; dy++) {
+        const y = by * 8 + dy;
+        const yGlobal = (startBy + by) * 8 + dy;
+        const bankOffset = (y & 0xC0) << 5;
+        const rowOffset = (y & 0x38) << 2;
+        const lineOffset = (y & 0x07) << 8;
+        const baseAddr = bankOffset | rowOffset | lineOffset | bx;
+        let byte = 0;
+        for (let bit = 0; bit < 8; bit++) {
+          const xGlobal = (startBx + bx) * 8 + bit;
+          let idx = 0;
+          if (xGlobal < W && yGlobal < H) idx = pixels[yGlobal * W + xGlobal];
+          byte |= (idx === attr.ink ? 1 : 0) << (7 - bit);
+        }
+        scr[baseAddr] = byte;
+      }
+      const attrAddr = 6144 + by * 32 + bx;
+      scr[attrAddr] = ((attr.flash ? 1 : 0) << 7) |
+        ((attr.bright ? 1 : 0) << 6) |
+        ((attr.paper & 7) << 3) |
+        (attr.ink & 7);
+    }
+  }
+
+  return scr;
+}
+
+function encodeTiles(indexed) {
+  const tilesX = Math.ceil(indexed.width / 256);
+  const tilesY = Math.ceil(indexed.height / 192);
+  const tiles = [];
+  for (let ty = 0; ty < tilesY; ty++) {
+    for (let tx = 0; tx < tilesX; tx++) {
+      tiles.push({ tx, ty, bytes: encodeTile(indexed, tx, ty) });
+    }
+  }
+  return tiles;
+}
+
+module.exports = { encodeTile, encodeTiles };


### PR DESCRIPTION
## Summary
- implement SCR tiling encoder and expose via `saveSCR`
- support exporting multiple tiles when image exceeds 256×192
- fill blank areas with default attributes
- add Node tests for tiling scenarios

## Testing
- `node tests/bright.test.js`
- `node tests/color.test.js`
- `node tests/indexed.test.js`
- `node tests/scr.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686bf0ec01648333a235626e60b20f5c