### PR TITLE
Add Flash layer support

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,6 +148,9 @@
         <option value="auto" selected>Auto</option>
       </select>
     </label>
+    <label>
+      <input type="checkbox" id="flashChk" /> Flash
+    </label>
     <button id="saveScrBtn">Save .scr</button>
   </div>
 

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ const { app, imaging, core, action } = require("photoshop");
 const { setupControls, loadSettings } = require("./ui/controls");
 const { reduceToDominantPair } = require("./filters/reduce");
 const { ditherSeparateChannels } = require("./filters/dither");
-const { rgbaToIndexed, indexedToRgba, computeBrightAttrs } = require("./utils/indexed");
+const { rgbaToIndexed, indexedToRgba, computeBrightAttrs, rgbToIndex } = require("./utils/indexed");
 const { encodeTiles } = require("./utils/scr");
 const { storage } = require("uxp");
 const fs = storage.localFileSystem;
@@ -44,6 +44,13 @@ let brightMode = (function() {
   return 'on'; // default to 'on'
 })();
 
+let flashEnabled = (function() {
+  const settings = (typeof loadSettings === 'function') ? loadSettings() : {};
+  return settings && settings.flashEnabled ? true : false;
+})();
+
+let flashPhase = false;
+
 function getScale() {
   return scale;
 }
@@ -63,8 +70,58 @@ function setBrightMode(v) {
   brightMode = v;
 }
 
+function setFlashEnabled(v) {
+  flashEnabled = !!v;
+}
+
+function findLayerByName(layers, name) {
+  for (const layer of layers) {
+    if (layer.name === name) return layer;
+    if (layer.layers && layer.layers.length) {
+      const found = findLayerByName(layer.layers, name);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function applyFlashAttrs(indexed, flashRgba, w, h) {
+  const cols = w >> 3;
+  const rows = h >> 3;
+  for (let by = 0; by < rows; by++) {
+    for (let bx = 0; bx < cols; bx++) {
+      const attr = indexed.attrs[by * cols + bx];
+      let flagged = false;
+      const freq = new Array(8).fill(0);
+      for (let dy = 0; dy < 8; dy++) {
+        const y = by * 8 + dy;
+        for (let dx = 0; dx < 8; dx++) {
+          const x = bx * 8 + dx;
+          const p = (y * w + x) * 4;
+          const a = flashRgba[p + 3];
+          if (a < 127) {
+            flagged = true;
+            if (attr.ink === attr.paper) {
+              const idx = rgbToIndex(flashRgba[p], flashRgba[p + 1], flashRgba[p + 2]);
+              freq[idx]++;
+            }
+          }
+        }
+      }
+      if (flagged) {
+        attr.flash = 1;
+        if (attr.ink === attr.paper) {
+          let best = 0, bestC = -1;
+          for (let i = 0; i < 8; i++) if (freq[i] > bestC) { bestC = freq[i]; best = i; }
+          attr.ink = best;
+        }
+      }
+    }
+  }
+}
+
 // Core filter
-function zxFilter(rgba, w, h) {
+function zxFilter(rgba, w, h, flashRgba = null) {
   let brightBits;
   if (brightMode === "auto") {
     const orig = new Uint8Array(rgba);
@@ -73,7 +130,9 @@ function zxFilter(rgba, w, h) {
   ditherSeparateChannels(rgba, w, h, selectedAlg, ditherT);
   reduceToDominantPair(rgba, w, h);
   const bright = brightMode === "on" ? 1 : 0;
-  return rgbaToIndexed(rgba, w, h, { bright, flash: 0, brightBits });
+  const indexed = rgbaToIndexed(rgba, w, h, { bright, flash: 0, brightBits });
+  if (flashEnabled && flashRgba) applyFlashAttrs(indexed, flashRgba, w, h);
+  return indexed;
 }
 
 async function fetchThumb() {
@@ -85,9 +144,17 @@ async function fetchThumb() {
     // 1) Отримуємо RGBA-пікселі через утиліту
     const { rgba } = await getRgbaPixels(imaging, { left: 0, top: 0, width: baseW, height: baseH }, false);
 
+    let flashRgba = null;
+    if (flashEnabled) {
+      let flashLayer = findLayerByName(d.layers, "FLASH");
+      if (!flashLayer) flashLayer = await d.createLayer({ name: "FLASH" });
+      const fr = await getRgbaPixels(imaging, { left: 0, top: 0, width: baseW, height: baseH, layerID: flashLayer.id }, true);
+      flashRgba = fr.rgba;
+    }
+
     // 2) Фільтруємо та отримуємо індексований буфер
-    const indexed = zxFilter(rgba, baseW, baseH);
-    const rgbaFiltered = indexedToRgba(indexed);
+    const indexed = zxFilter(rgba, baseW, baseH, flashRgba);
+    const rgbaFiltered = indexedToRgba(indexed, flashPhase && flashEnabled);
 
     // 3) Upscale + JPEG encode (fixed preview always 4×)
     const s = 4;
@@ -172,7 +239,14 @@ async function saveSCR() {
 
       // Отримуємо RGBA-пікселі через утиліту
       const { rgba } = await getRgbaPixels(imaging, { left: 0, top: 0, width: W, height: H }, false);
-      indexed = zxFilter(rgba, W, H);
+      let flashRgba = null;
+      if (flashEnabled) {
+        let flashLayer = findLayerByName(doc.layers, "FLASH");
+        if (!flashLayer) flashLayer = await doc.createLayer({ name: "FLASH" });
+        const fr = await getRgbaPixels(imaging, { left: 0, top: 0, width: W, height: H, layerID: flashLayer.id }, true);
+        flashRgba = fr.rgba;
+      }
+      indexed = zxFilter(rgba, W, H, flashRgba);
     },
     { commandName: "Fetch & Filter Pixels" }
   );
@@ -214,7 +288,8 @@ document.addEventListener("DOMContentLoaded", () => {
     getLastDimensions,
     setAlgorithm,
     setDitherStrength,
-    setBrightMode, // ← новий сеттер
+    setBrightMode,
+    setFlashEnabled,
     saveSCR, // ← функція експорту
   });
 
@@ -223,6 +298,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Fallback interval
   setInterval(() => {
+    if (flashEnabled) flashPhase = !flashPhase;
     if (!updatePreview._running) updatePreview();
   }, 500);
 });

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -3,6 +3,17 @@ const { app, imaging, core } = require("photoshop");
 const { getRgbaPixels } = require("../utils/utils");
 const { indexedToRgba } = require("../utils/indexed");
 
+function findLayerByName(layers, name) {
+  for (const layer of layers) {
+    if (layer.name === name) return layer;
+    if (layer.layers && layer.layers.length) {
+      const found = findLayerByName(layer.layers, name);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
 function getDomElements() {
   return {
     btnDown: document.getElementById("scaleDown"),
@@ -15,6 +26,7 @@ function getDomElements() {
     rngStr: document.getElementById("ditherStrength"),
     lblStr: document.getElementById("ditherLabel"),
     brightSel: document.getElementById("brightModeSel"),
+    flashChk: document.getElementById("flashChk"),
     saveScrBtn: document.getElementById("saveScrBtn"),
   };
 }
@@ -41,6 +53,7 @@ function setupControls({
   setAlgorithm,
   setDitherStrength,
   setBrightMode,
+  setFlashEnabled,
   saveSCR,
 }) {
   const {
@@ -54,6 +67,7 @@ function setupControls({
     rngStr,
     lblStr,
     brightSel,
+    flashChk,
     saveScrBtn,
   } = getDomElements();
 
@@ -66,6 +80,10 @@ function setupControls({
   if (settings.systemScale && selSys) selSys.value = settings.systemScale;
   if (settings.ditherAlg && selAlg) selAlg.value = settings.ditherAlg;
   if (settings.brightMode && brightSel) brightSel.value = settings.brightMode;
+  if (typeof settings.flashEnabled === 'boolean' && flashChk) {
+    flashChk.checked = settings.flashEnabled;
+    setFlashEnabled(flashChk.checked);
+  }
 
   // Синхронізуємо selectedAlg у main.js з UI після відновлення
   if (selAlg) setAlgorithm(selAlg.value);
@@ -79,7 +97,8 @@ function setupControls({
       scalePreview: scale,
       systemScale: selSys?.value,
       ditherAlg: selAlg?.value,
-      brightMode: brightSel?.value
+      brightMode: brightSel?.value,
+      flashEnabled: flashChk?.checked
     });
     updatePreview();
   }
@@ -92,7 +111,8 @@ function setupControls({
       ditherAlg: selAlg.value,
       scalePreview: getScale(),
       systemScale: selSys?.value,
-      brightMode: brightSel?.value
+      brightMode: brightSel?.value,
+      flashEnabled: flashChk?.checked
     });
     updatePreview();
   });
@@ -105,7 +125,21 @@ function setupControls({
       brightMode: brightSel.value,
       scalePreview: getScale(),
       systemScale: selSys?.value,
-      ditherAlg: selAlg?.value
+      ditherAlg: selAlg?.value,
+      flashEnabled: flashChk?.checked
+    });
+    updatePreview();
+  });
+
+  flashChk?.addEventListener("change", () => {
+    setFlashEnabled(flashChk.checked);
+    saveSettings({
+      ...loadSettings(),
+      flashEnabled: flashChk.checked,
+      scalePreview: getScale(),
+      systemScale: selSys?.value,
+      ditherAlg: selAlg?.value,
+      brightMode: brightSel?.value
     });
     updatePreview();
   });
@@ -149,7 +183,8 @@ function setupControls({
       systemScale: selSys.value,
       scalePreview: getScale(),
       ditherAlg: selAlg?.value,
-      brightMode: brightSel?.value
+      brightMode: brightSel?.value,
+      flashEnabled: flashChk?.checked
     });
     updatePreview();
   });
@@ -165,9 +200,16 @@ function setupControls({
         const H = Math.round(+d.height);
         // Отримуємо RGBA через утиліту
         const { rgba } = await getRgbaPixels(imaging, { left: 0, top: 0, width: W, height: H }, true);
+        let flashRgba = null;
+        if (flashChk?.checked) {
+          let flashLayer = findLayerByName(d.layers, "FLASH");
+          if (!flashLayer) flashLayer = await d.createLayer({ name: "FLASH" });
+          const fr = await getRgbaPixels(imaging, { left: 0, top: 0, width: W, height: H, layerID: flashLayer.id }, true);
+          flashRgba = fr.rgba;
+        }
         // Застосовуємо фільтр ZX
-        const indexed = zxFilter(rgba, W, H);
-        const outRgba = indexedToRgba(indexed);
+        const indexed = zxFilter(rgba, W, H, flashRgba);
+        const outRgba = indexedToRgba(indexed, false);
         const newData = await imaging.createImageDataFromBuffer(outRgba, {
           width: W,
           height: H,

--- a/utils/indexed.js
+++ b/utils/indexed.js
@@ -121,7 +121,7 @@ function indexToRgb(idx, bright) {
   return base;
 }
 
-function indexedToRgba({ pixels, attrs, width: w, height: h }) {
+function indexedToRgba({ pixels, attrs, width: w, height: h }, swapFlash = false) {
   const rgba = new Uint8Array(w * h * 4);
   const cols = w >> 3;
   for (let y = 0; y < h; y++) {
@@ -129,7 +129,10 @@ function indexedToRgba({ pixels, attrs, width: w, height: h }) {
     for (let x = 0; x < w; x++) {
       const bx = x >> 3;
       const attr = attrs[by * cols + bx];
-      const idx = pixels[y * w + x];
+      let idx = pixels[y * w + x];
+      if (swapFlash && attr.flash) {
+        if (idx === attr.ink) idx = attr.paper; else if (idx === attr.paper) idx = attr.ink;
+      }
       const [r, g, b] = indexToRgb(idx, attr.bright);
       const p = (y * w + x) * 4;
       rgba[p] = r;
@@ -141,4 +144,4 @@ function indexedToRgba({ pixels, attrs, width: w, height: h }) {
   return rgba;
 }
 
-module.exports = { rgbaToIndexed, indexedToRgba, computeBrightAttrs, ZX_BASE };
+module.exports = { rgbaToIndexed, indexedToRgba, computeBrightAttrs, ZX_BASE, rgbToIndex };

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -8,12 +8,14 @@
  * @returns {Promise<{rgba: Uint8Array, width: number, height: number}>}
  */
 async function getRgbaPixels(imaging, options, applyAlpha = true) {
-  const { left, top, width, height } = options;
-  const { imageData } = await imaging.getPixels({
+  const { left, top, width, height, layerID } = options;
+  const getOpts = {
     sourceBounds: { left, top, width, height },
     targetSize: { width, height },
     applyAlpha,
-  });
+  };
+  if (layerID !== undefined) getOpts.layerID = layerID;
+  const { imageData } = await imaging.getPixels(getOpts);
   const data = await imageData.getData();
   imageData.dispose();
   const pxCount = width * height;


### PR DESCRIPTION
## Summary
- add optional Flash layer detection and flash attributes
- allow preview blinking with Flash blocks
- hook up flash checkbox in UI and save setting
- update utils for layer pixel grabbing and flash rendering

## Testing
- `node tests/color.test.js`
- `node tests/bright.test.js`
- `node tests/indexed.test.js`
- `node tests/scr.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686cd69add808333a7d6cdccda6cebc8