### PR TITLE
Add configurable ZX palette helper

### DIFF
--- a/filters/reduce.js
+++ b/filters/reduce.js
@@ -1,14 +1,7 @@
+const { ZX_BASE_255 } = require('../utils/palette');
+
 function reduceToDominantPair(rgba, w, h) {
-const ZX_BASE = [
-  [0, 0, 0],
-  [0, 0, 255],
-  [255, 0, 0],
-  [255, 0, 255],
-  [0, 255, 0],
-  [0, 255, 255],
-  [255, 255, 0],
-  [255, 255, 255],
-];
+  const ZX_BASE = ZX_BASE_255;
 
   const blocksX = Math.floor(w / 8);
   const blocksY = Math.floor(h / 8);
@@ -62,5 +55,4 @@ const ZX_BASE = [
     }
   }
 }
-
 module.exports = { reduceToDominantPair };

--- a/utils/indexed.js
+++ b/utils/indexed.js
@@ -1,24 +1,8 @@
 // utils/indexed.js
 // Conversion between RGBA buffers and ZX Spectrum indexed representation
 
-const ZX_BASE = [
-  [0, 0, 0],
-  [0, 0, 192],
-  [192, 0, 0],
-  [192, 0, 192],
-  [0, 192, 0],
-  [0, 192, 192],
-  [192, 192, 0],
-  [192, 192, 192],
-];
-
-// Helper palette including bright variants (skip bright black)
-const ZX_FULL = [];
-for (let i = 0; i < 8; i++) ZX_FULL.push({ rgb: ZX_BASE[i], bright: false });
-for (let i = 1; i < 8; i++) {
-  const [r, g, b] = ZX_BASE[i].map(v => (v === 0 ? 0 : 255));
-  ZX_FULL.push({ rgb: [r, g, b], bright: true });
-}
+// Import universal palettes
+const { ZX_BASE, ZX_FULL } = require('./palette');
 
 function rgbToIndex(r, g, b) {
   const rBit = r >= 128 ? 1 : 0;
@@ -152,4 +136,11 @@ function indexedToRgba({ pixels, attrs, width: w, height: h }, swapFlash = false
   return rgba;
 }
 
-module.exports = { rgbaToIndexed, indexedToRgba, computeBrightAttrs, ZX_BASE, rgbToIndex };
+module.exports = {
+  rgbaToIndexed,
+  indexedToRgba,
+  computeBrightAttrs,
+  ZX_BASE,
+  ZX_FULL,
+  rgbToIndex,
+};

--- a/utils/palette.js
+++ b/utils/palette.js
@@ -1,0 +1,72 @@
+// utils/palette.js
+// Universal ZX Spectrum palette helpers
+
+// configurable dim brightness (0..255)
+let dimLevel = 192;
+
+/**
+ * Change dim color intensity and rebuild palettes.
+ * @param {number} level New value from 0..255
+ */
+function setDimLevel(level) {
+  dimLevel = level;
+  buildPalettes();
+}
+
+/**
+ * Get current dim level.
+ */
+function getDimLevel() {
+  return dimLevel;
+}
+
+// Base 3-bit palette used for preview (dim colors only)
+let ZX_BASE = [];
+// Extended palette with dim + bright variants (bright black repeats black)
+// objects contain { rgb: [r,g,b], bright: boolean }
+let ZX_FULL = [];
+// Palette with 0/255 values used by reduce step
+const ZX_BASE_255 = [
+  [0, 0, 0],
+  [0, 0, 255],
+  [255, 0, 0],
+  [255, 0, 255],
+  [0, 255, 0],
+  [0, 255, 255],
+  [255, 255, 0],
+  [255, 255, 255],
+];
+
+function buildPalettes() {
+  ZX_BASE = [
+    [0, 0, 0],
+    [0, 0, dimLevel],
+    [dimLevel, 0, 0],
+    [dimLevel, 0, dimLevel],
+    [0, dimLevel, 0],
+    [0, dimLevel, dimLevel],
+    [dimLevel, dimLevel, 0],
+    [dimLevel, dimLevel, dimLevel],
+  ];
+  ZX_FULL = [];
+  // push dim colors
+  for (let i = 0; i < 8; i++) {
+    ZX_FULL.push({ rgb: ZX_BASE[i], bright: false });
+  }
+  // push bright variants (black repeats)
+  for (let i = 0; i < 8; i++) {
+    const rgb = i === 0 ? [0, 0, 0] : ZX_BASE[i].map(v => (v === 0 ? 0 : 255));
+    ZX_FULL.push({ rgb, bright: true });
+  }
+}
+
+// build palettes once with default dim level
+buildPalettes();
+
+module.exports = {
+  ZX_BASE,
+  ZX_FULL,
+  ZX_BASE_255,
+  setDimLevel,
+  getDimLevel,
+};


### PR DESCRIPTION
## Summary
- centralize ZX Spectrum palette data in new `utils/palette.js`
- use the universal palette in `reduce` and `indexed` utils
- export bright/dim palette variations and expose dim level setter

## Testing
- `node tests/color.test.js`
- `node tests/indexed.test.js`
- `node tests/bright.test.js`
- `node tests/scr.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686e26daf0548333a87d888ae5bfc4f1