### PR TITLE
Add ink-paper equality rule

### DIFF
--- a/tests/scr.test.js
+++ b/tests/scr.test.js
@@ -102,4 +102,17 @@ function decode(scr) {
   });
 })();
 
+// Case 5: INK equals PAPER -> pixels should be 0
+(() => {
+  const idx = makeIndexed(8, 8, 3, 3);
+  const tiles = encodeTiles(idx);
+  assert.strictEqual(tiles.length, 1);
+  const d = decode(tiles[0].bytes);
+  for (const val of d.pixels) assert.strictEqual(val, 0);
+  for (let i = 0; i < d.attrs.length; i++) {
+    const a = d.attrs[i];
+    if (i === 0) assert.strictEqual(a, 27); else assert.strictEqual(a, 7);
+  }
+})();
+
 console.log('SCR tiling tests passed');

--- a/utils/scr.js
+++ b/utils/scr.js
@@ -26,6 +26,10 @@ function encodeTile(indexed, tx = 0, ty = 0) {
         const rowOffset = (y & 0x38) << 2;
         const lineOffset = (y & 0x07) << 8;
         const baseAddr = bankOffset | rowOffset | lineOffset | bx;
+        if (attr.ink === attr.paper) {
+          scr[baseAddr] = 0;
+          continue;
+        }
         let byte = 0;
         for (let bit = 0; bit < 8; bit++) {
           const xGlobal = (startBx + bx) * 8 + bit;


### PR DESCRIPTION
## Summary
- treat tiles where ink equals paper as empty in `encodeTile`
- add a test covering the new rule

## Testing
- `node tests/bright.test.js`
- `node tests/color.test.js`
- `node tests/indexed.test.js`
- `node tests/scr.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686e671b05288333a22f79af057b2fd1