### PR TITLE
Add history state to ZX filter action

### DIFF
--- a/ui/controls.js
+++ b/ui/controls.js
@@ -214,7 +214,10 @@ function setupControls({
           replace: true,
         });
         newData.dispose();
-      }, { commandName: "Apply ZX Filter" });
+      }, {
+        commandName: "Apply ZX Filter",
+        historyStateInfo: { name: "Apply ZX Filter", target: app.activeDocument }
+      });
     } finally {
       btnApply.disabled = false;
       updatePreview();


### PR DESCRIPTION
## Summary
- include `historyStateInfo` in `btnApply` click handler

## Testing
- `node tests/bright.test.js`
- `node tests/color.test.js`
- `node tests/indexed.test.js`
- `node tests/scr.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6870d1f3f3bc83339756ee029a5e7e2e