### PR TITLE
Handle modal state before preview update

### DIFF
--- a/main.js
+++ b/main.js
@@ -127,6 +127,11 @@ function zxFilter(rgba, w, h, flashRgba = null) {
 async function fetchThumb() {
   const d = app.activeDocument;
   if (!d) return null;
+  // If the host is already in a modal state (e.g. a dialog is open)
+  // skip fetching the preview to avoid errors
+  if (core.isModal && typeof core.isModal === "function" && core.isModal()) {
+    return null;
+  }
   return await core.executeAsModal(async () => {
     const baseW = Math.round(+d.width);
     const baseH = Math.round(+d.height);


### PR DESCRIPTION
## Summary
- check if Photoshop is in modal state before executing `fetchThumb`

## Testing
- `node tests/bright.test.js && node tests/color.test.js && node tests/indexed.test.js && node tests/scr.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6870d551d5388333bf1775a6078f43c4