### PR TITLE
Fix dither strength slider timing

### DIFF
--- a/main.js
+++ b/main.js
@@ -55,6 +55,19 @@ let lastSettingsKey = "";
 let thumbCache = { off: "", on: "", indexed: null, w: 0, h: 0 };
 let pixelCache = { rgba: null, flashRgba: null, w: 0, h: 0 };
 
+// Track slider interaction state
+let sliderDragging = false;
+let sliderReleasedAt = 0;
+
+function setSliderDragging(v) {
+  sliderDragging = !!v;
+  if (!v) sliderReleasedAt = Date.now();
+}
+
+function isSliderLocked() {
+  return sliderDragging || Date.now() - sliderReleasedAt < 500;
+}
+
 function getScale() {
   return scale;
 }
@@ -228,6 +241,10 @@ async function updatePreview(cacheOnly = false) {
     setTimeout(() => updatePreview(cacheOnly), 250);
     return;
   }
+  if (!cacheOnly && isSliderLocked()) {
+    setTimeout(() => updatePreview(cacheOnly), 100);
+    return;
+  }
   if (updatePreview._running || busy) {
     if (updatePreview._pending !== false) {
       updatePreview._pending = cacheOnly;
@@ -374,6 +391,7 @@ document.addEventListener("DOMContentLoaded", () => {
     getLastDimensions,
     setAlgorithm,
     setDitherStrength,
+    setSliderDragging,
     setBrightMode,
     setFlashEnabled,
     saveSCR, // ← функція експорту

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -41,6 +41,7 @@ function setupControls({
   getLastDimensions,
   setAlgorithm,
   setDitherStrength,
+  setSliderDragging,
   setBrightMode,
   setFlashEnabled,
   saveSCR,
@@ -143,10 +144,13 @@ function setupControls({
     const v = Number(rngStr.value);
     lblStr.textContent = v + "%";
     setDitherStrength(v / 100);
-    updatePreview();
+    setSliderDragging(true);
+    updatePreview(true);
   });
   rngStr?.addEventListener("change", () => {
+    setSliderDragging(false);
     updatePreview(true);
+    setTimeout(() => updatePreview(), 500);
   });
 
   // Scale Preview controls


### PR DESCRIPTION
## Summary
- add slider drag state handling
- avoid document analysis while slider is dragged
- delay analysis for half a second after release

## Testing
- `for f in tests/*.js; do node "$f" || break; done`

------
https://chatgpt.com/codex/tasks/task_e_68727d015db4833383e7930df84ea270