### PR TITLE
Prevent doc analysis during slider drag

### DIFF
--- a/ui/controls.js
+++ b/ui/controls.js
@@ -44,6 +44,9 @@ function setupControls({
   setBrightMode,
   setFlashEnabled,
   saveSCR,
+  postponeAnalysis,
+  startSliderDrag,
+  stopSliderDrag,
 }) {
   const {
     btnDown,
@@ -139,15 +142,18 @@ function setupControls({
   });
 
   // Strength slider
+  rngStr?.addEventListener("pointerdown", startSliderDrag);
+  rngStr?.addEventListener("pointerup", stopSliderDrag);
+  rngStr?.addEventListener("pointercancel", stopSliderDrag);
+
   rngStr?.addEventListener("input", () => {
     const v = Number(rngStr.value);
     lblStr.textContent = v + "%";
     setDitherStrength(v / 100);
+    postponeAnalysis();
     updatePreview(true);
   });
-  rngStr?.addEventListener("change", () => {
-    updatePreview();
-  });
+  rngStr?.addEventListener("change", stopSliderDrag);
 
   // Scale Preview controls
   btnDown?.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- avoid document analysis while the dither strength slider is dragged
- switch to cached preview updates during drag using new helper
- resume normal analysis half a second after release

## Testing
- `node tests/bright.test.js`
- `node tests/color.test.js`
- `node tests/indexed.test.js`
- `node tests/scr.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68727af11ea48333a5c7f31e3df20a24