### PR TITLE
Fix dither strength slider timing

### DIFF
--- a/ui/controls.js
+++ b/ui/controls.js
@@ -41,6 +41,8 @@ function setupControls({
   getLastDimensions,
   setAlgorithm,
   setDitherStrength,
+  setSliderDragging,
+  notifySliderChange,
   setBrightMode,
   setFlashEnabled,
   saveSCR,
@@ -143,10 +145,13 @@ function setupControls({
     const v = Number(rngStr.value);
     lblStr.textContent = v + "%";
     setDitherStrength(v / 100);
-    updatePreview();
+    setSliderDragging(true);
+    notifySliderChange();
   });
   rngStr?.addEventListener("change", () => {
-    updatePreview(true);
+    setSliderDragging(false);
+    notifySliderChange();
+    setTimeout(() => updatePreview(), 500);
   });
 
   // Scale Preview controls


### PR DESCRIPTION
## Summary
- add slider drag state handling
- avoid document analysis while slider is dragged
- delay analysis for half a second after release
- refresh preview in realtime while dragging

## Testing
- `for f in tests/*.js; do node "$f" || break; done`


------
https://chatgpt.com/codex/tasks/task_e_68727d015db4833383e7930df84ea270