### PR TITLE
Implement basic attribute optimizer

### DIFF
--- a/tests/scr.test.js
+++ b/tests/scr.test.js
@@ -111,7 +111,7 @@ function decode(scr) {
   for (const val of d.pixels) assert.strictEqual(val, 0);
   for (let i = 0; i < d.attrs.length; i++) {
     const a = d.attrs[i];
-    if (i === 0) assert.strictEqual(a, 27); else assert.strictEqual(a, 7);
+    if (i === 0) assert.strictEqual(a, 28); else assert.strictEqual(a, 7);
   }
 })();
 

--- a/utils/scr.js
+++ b/utils/scr.js
@@ -50,7 +50,10 @@ function encodeTile(indexed, tx = 0, ty = 0) {
   return scr;
 }
 
+const { optimizeAttributes } = require('./indexed');
+
 function encodeTiles(indexed) {
+  optimizeAttributes(indexed);
   const tilesX = Math.ceil(indexed.width / 256);
   const tilesY = Math.ceil(indexed.height / 192);
   const tiles = [];


### PR DESCRIPTION
## Summary
- implement image brightness check and attribute optimizer
- apply optimizer during SCR export
- update test expectations for INK=paper case
- simplify `_isImageDark` by summing indices

## Testing
- `node tests/indexed.test.js`
- `node tests/bright.test.js`
- `node tests/scr.test.js`


------
https://chatgpt.com/codex/tasks/task_e_687294250ddc8333a13abc5243c58e31