### PR TITLE
Fix decimal value not sticking to preset

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@
         <sp-menu-item value="custom">
           <div style="display:flex; align-items:center;">
             <span>Custom</span>
-            <sp-textfield disabled quiet id="customField" type="number" placeholder="100–500" min="100" max="500"
+            <sp-textfield disabled quiet id="customField" type="number" step="0.1" placeholder="100–500" min="100" max="500"
               style="width:70px; margin: 0px 8px; padding: 0;"></sp-textfield>
           </div>
         </sp-menu-item>

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -263,14 +263,16 @@ function setupControls({
     }
     prevScale = getSystemScale();
     if (pickerDialog) {
-      const current = Math.round(prevScale * 1000)/10 || 100;
-      const preset = ["100","125","150","175","200","225","250"];
-      let target = preset.includes(String(current)) ? String(current) : "custom";
+      const raw = prevScale * 100;
+      const current = parseFloat(raw.toFixed(1)) || 100;
+      const presetVals = [100, 125, 150, 175, 200, 225, 250];
+      const match = presetVals.find(p => Math.abs(p - raw) < 0.001);
+      const target = match ? String(match) : "custom";
       pickerDialog.querySelectorAll("sp-menu-item").forEach((i) => i.removeAttribute("selected"));
       const item = pickerDialog.querySelector(`sp-menu-item[value="${target}"]`);
       if (item) item.setAttribute("selected", "");
       pickerDialog.value = target;
-      customField.value = String(current);
+      customField.value = current.toFixed(1);
       if (target === "custom") {
         customField.disabled = false;
         customField.style.display = "";


### PR DESCRIPTION
## Summary
- refine detection logic when reopening preferences so decimals aren't mistaken for preset values

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6878d8961a2c83339512998a877e5dff