### PR TITLE
Rename preview scale variables to zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,15 +170,15 @@
 
   <div id="controls" class="group">
 
-    <sp-action-button class="control-button" id="scaleDown" icon-only aria-label="Зменшити масштаб">
+    <sp-action-button class="control-button" id="zoomDown" icon-only aria-label="Зменшити масштаб">
       <img class="icon" src="img/zoom-minus.svg" alt="" />
     </sp-action-button>
 
 
-    <sp-heading size="XXS" style="width: 10px;"><span id="scaleLabel">3x</span></sp-heading>
+    <sp-heading size="XXS" style="width: 10px;"><span id="zoomLabel">3x</span></sp-heading>
 
 
-    <sp-action-button class="control-button" id="scaleUp" icon-only aria-label="Збільшити масштаб">
+    <sp-action-button class="control-button" id="zoomUp" icon-only aria-label="Збільшити масштаб">
       <img class="icon" src="img/zoom-plus.svg" alt="" />
     </sp-action-button>
 

--- a/main.js
+++ b/main.js
@@ -13,14 +13,14 @@ const { getRgbaPixels, ensureFlashLayer } = require("./utils/utils");
 // DOM elements
 const img = document.getElementById("previewImg");
 const msg = document.getElementById("invalidMsg");
-const btnDown = document.getElementById("scaleDown");
-const btnUp = document.getElementById("scaleUp");
-const lblScale = document.getElementById("scaleLabel");
+const btnDown = document.getElementById("zoomDown");
+const btnUp = document.getElementById("zoomUp");
+const lblZoom = document.getElementById("zoomLabel");
 const selSys = document.getElementById("sysScaleSel");
 const btnApply = document.getElementById("applyBtn");
 
 // State
-let scale = 3;
+let zoom = 3;
 let systemScale = (function () {
   const settings = (typeof loadSettings === 'function') ? loadSettings() : {};
   if (settings && settings.systemScale) return parseFloat(settings.systemScale) || 1;
@@ -99,11 +99,11 @@ function isSliderLocked() {
   return sliderDragging || Date.now() - sliderReleasedAt < 500;
 }
 
-function getScale() {
-  return scale;
+function getZoom() {
+  return zoom;
 }
-function setScale(v) {
-  scale = v;
+function setZoom(v) {
+  zoom = v;
 }
 
 function getSystemScale() {
@@ -376,7 +376,7 @@ async function updatePreview(cacheOnly = false) {
     }
     const srcB64 = flashPhase && flashEnabled ? thumbCache.on : thumbCache.off;
     const sysScale = getSystemScale();
-    const s = getScale();
+    const s = getZoom();
     img.style.width = (thumbCache.w * s / 4) / sysScale + "px";
     img.style.height = (thumbCache.h * s / 4) / sysScale + "px";
     if (srcB64) img.src = "data:image/jpeg;base64," + srcB64;
@@ -470,8 +470,8 @@ document.addEventListener("DOMContentLoaded", () => {
   setupControls({
     zxFilter,
     updatePreview,
-    getScale,
-    setScale,
+    getZoom,
+    setZoom,
     getSystemScale,
     setSystemScale,
     getLastDimensions,

--- a/ui-v2/index.html
+++ b/ui-v2/index.html
@@ -18,7 +18,7 @@
             alt="Zoom out"
           />
         </button>
-        <div class="scale-label" aria-label="Current zoom level">
+        <div class="zoom-label" aria-label="Current zoom level">
           <span class="text-wrapper">4x</span>
         </div>
         <button class="control-button" aria-label="Zoom in">

--- a/ui-v2/style.css
+++ b/ui-v2/style.css
@@ -42,7 +42,7 @@
   height: 18px;
 }
 
-.controls .scale-label {
+.controls .zoom-label {
   width: 16px;
   display: flex;
   height: 32px;
@@ -359,7 +359,7 @@
   height: 18px;
 }
 
-.controls .scale-label {
+.controls .zoom-label {
   width: 16px;
   display: flex;
   height: 32px;

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -5,9 +5,9 @@ const { indexedToRgba } = require("../utils/indexed");
 
 function getDomElements() {
   return {
-    btnDown: document.getElementById("scaleDown"),
-    btnUp: document.getElementById("scaleUp"),
-    lblScale: document.getElementById("scaleLabel"),
+    btnDown: document.getElementById("zoomDown"),
+    btnUp: document.getElementById("zoomUp"),
+    lblZoom: document.getElementById("zoomLabel"),
     selSys: document.getElementById("sysScaleSel"),
     img: document.getElementById("previewImg"),
     btnApply: document.getElementById("applyBtn"),
@@ -41,8 +41,8 @@ function loadSettings() {
 function setupControls({
   zxFilter,
   updatePreview,
-  getScale,
-  setScale,
+  getZoom,
+  setZoom,
   getSystemScale,
   setSystemScale,
   getLastDimensions,
@@ -57,7 +57,7 @@ function setupControls({
   const {
     btnDown,
     btnUp,
-    lblScale,
+    lblZoom,
     selSys,
     img,
     btnApply,
@@ -76,9 +76,10 @@ function setupControls({
 
   // Відновлення налаштувань при старті
   const settings = loadSettings();
-  if (settings.scalePreview) {
-    setScale(settings.scalePreview);
-    lblScale.textContent = settings.scalePreview + "x";
+  const previewZoom = settings.zoomPreview || settings.scalePreview;
+  if (previewZoom) {
+    setZoom(previewZoom);
+    lblZoom.textContent = previewZoom + "x";
   }
   if (settings.systemScale) {
     setSystemScale(parseFloat(settings.systemScale) || 1);
@@ -94,13 +95,13 @@ function setupControls({
   // Синхронізуємо selectedAlg у main.js з UI після відновлення
   if (selAlg) setAlgorithm(selAlg.value);
 
-  // Helper to update scale label and preview
-  function updateScaleLabelAndPreview() {
-    const scale = getScale();
-    lblScale.textContent = scale + "x";
+  // Helper to update zoom label and preview
+  function updateZoomLabelAndPreview() {
+    const zoom = getZoom();
+    lblZoom.textContent = zoom + "x";
     saveSettings({
       ...loadSettings(),
-      scalePreview: scale,
+      zoomPreview: zoom,
       systemScale: getSystemScale(),
       ditherAlg: selAlg?.value,
       brightMode: brightSel?.value,
@@ -115,7 +116,7 @@ function setupControls({
     saveSettings({
       ...loadSettings(),
       ditherAlg: selAlg.value,
-      scalePreview: getScale(),
+      zoomPreview: getZoom(),
       systemScale: getSystemScale(),
       brightMode: brightSel?.value,
       flashEnabled: flashChk?.checked
@@ -129,7 +130,7 @@ function setupControls({
     saveSettings({
       ...loadSettings(),
       brightMode: brightSel.value,
-      scalePreview: getScale(),
+      zoomPreview: getZoom(),
       systemScale: getSystemScale(),
       ditherAlg: selAlg?.value,
       flashEnabled: flashChk?.checked
@@ -142,7 +143,7 @@ function setupControls({
     saveSettings({
       ...loadSettings(),
       flashEnabled: flashChk.checked,
-      scalePreview: getScale(),
+      zoomPreview: getZoom(),
       systemScale: getSystemScale(),
       ditherAlg: selAlg?.value,
       brightMode: brightSel?.value
@@ -169,17 +170,17 @@ function setupControls({
     setTimeout(() => updatePreview(), 500);
   });
 
-  // Scale Preview controls
+  // Preview Zoom controls
   btnDown?.addEventListener("click", () => {
-    let s = getScale();
-    if (s > 1) setScale(s - 1);
-    updateScaleLabelAndPreview();
+    let s = getZoom();
+    if (s > 1) setZoom(s - 1);
+    updateZoomLabelAndPreview();
   });
 
   btnUp?.addEventListener("click", () => {
-    let s = getScale();
-    if (s < 4) setScale(s + 1);
-    updateScaleLabelAndPreview();
+    let s = getZoom();
+    if (s < 4) setZoom(s + 1);
+    updateZoomLabelAndPreview();
   });
 
   // system Scale selector
@@ -194,7 +195,7 @@ function setupControls({
     saveSettings({
       ...loadSettings(),
       systemScale: getSystemScale(),
-      scalePreview: getScale(),
+      zoomPreview: getZoom(),
       ditherAlg: selAlg?.value,
       brightMode: brightSel?.value,
       flashEnabled: flashChk?.checked
@@ -308,7 +309,7 @@ function setupControls({
         saveSettings({
           ...loadSettings(),
           systemScale: ssVal,
-          scalePreview: getScale(),
+          zoomPreview: getZoom(),
           ditherAlg: selAlg?.value,
           brightMode: brightSel?.value,
           flashEnabled: flashChk?.checked
@@ -374,4 +375,4 @@ function setupControls({
 }
 
 
-module.exports = { setupControls, loadSettings };
+module.exports = { setupControls, loadSettings }


### PR DESCRIPTION
## Summary
- rename preview scale variables and UI IDs from *scale* to *zoom*
- adjust functions and settings accordingly

## Testing
- `node tests/bright.test.js`
- `node tests/color.test.js`
- `node tests/indexed.test.js`
- `node tests/scr.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6878e294ba8c83338d66365db4a46939