### PR TITLE
Support 16‑bit images

### DIFF
--- a/main.js
+++ b/main.js
@@ -326,7 +326,7 @@ async function updatePreview(cacheOnly = false) {
         docH % 8 ||
         docW > 512 ||
         docH > 384 ||
-        !/8/.test(bits) || // d.bitsPerChannel returns string "bitDepth8"
+        !/(8|16)/.test(bits) || // supports 8-bit and 16-bit
         !/rgb/.test(modeStr);
 
       const formatChanged =

--- a/tests/bitdepth16.test.js
+++ b/tests/bitdepth16.test.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+const { convertTo8BitRgba } = require('../utils/utils');
+
+// RGBA input in 16 bits per channel
+const dataRgba16 = new Uint16Array([
+  65535, 32768, 0, 65535, // pixel 0
+  0, 32768, 65535, 0      // pixel 1
+]);
+const out1 = convertTo8BitRgba(dataRgba16, 2);
+assert.deepStrictEqual(Array.from(out1), [255, 128, 0, 255, 0, 128, 255, 0]);
+
+// RGB input in 16 bits per channel
+const dataRgb16 = new Uint16Array([
+  0, 65535, 32768, // pixel 0
+  65535, 0, 0      // pixel 1
+]);
+const out2 = convertTo8BitRgba(dataRgb16, 2);
+assert.deepStrictEqual(Array.from(out2), [0, 255, 128, 255, 255, 0, 0, 255]);
+
+console.log('Bit depth 16 conversion tests passed');


### PR DESCRIPTION
## Summary
- allow `bitDepth16` documents
- handle 16‑bit pixel data by converting to 8‑bit RGBA
- export helper `convertTo8BitRgba`
- add regression test for 16‑bit conversion

## Testing
- `node tests/bitdepth16.test.js`
- `node tests/color.test.js`
- `node tests/bright.test.js`
- `node tests/indexed.test.js`
- `node tests/scr.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6879ff11b1a48333a9291c56f1b1a7d0