### PR TITLE
Flash toggle button and delayed tooltips

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,19 +159,12 @@
     }
 
     .tooltip sp-tooltip {
-      display: none;
       position: absolute;
       bottom: 133%;
       left: 50%;                /* зліва від середини контейнера */
       transform: translateX(-50%); /* центр по горизонталі */
       right: 0;
       text-align: center;
-      
-    }
-
-    .tooltip:hover sp-tooltip {
-      display: block;
-      
     }
   </style>
 </head>
@@ -280,7 +273,7 @@
     </label>
 
     <sp-action-button class="tooltip" id="applyBtn" style="width: 99px;">Paste
-      <sp-tooltip open placement="top" variant="info" style="width: 100px;">Paste to new layer</sp-tooltip>
+      <sp-tooltip placement="top" variant="info" style="width: 100px;">Paste to new layer</sp-tooltip>
     </sp-action-button>
 
     <label>
@@ -323,7 +316,6 @@
 
     <label
       title="1. To activate the flash bit, put pixels in a layer named FLASH.&#10;2. If a block contains only one color, the second color will be taken from this layer.&#10;3. Hide the FLASH layer so it does not affect the visible result.">
-      <sp-switch emphasized id="flashChk" label="Flash">Flash</sp-switch>
       <sp-action-button class="control-button" id="flashChk" icon-only style="margin: 0px 6px;">
         <svg width="18" height="18" slot="icon" id="flashOff" fill="currentColor">
           <path d="M11.25 0.861908L8.03544 4.88011L9.10263 5.94729L9.75 5.13808V6.59466L11.4053 8.24999H11.9395L11.7021 8.54677L12.7693 9.61396L15.0605 6.74999H11.25V0.861908Z"/>
@@ -334,10 +326,9 @@
         </svg>
       </sp-action-button>
     </label>
-   </sp-action-button>
 
     <sp-action-button class="tooltip" id="saveScrBtn">Export
-      <sp-tooltip open placement="top" variant="info" style="width: 100px;">Export *.scr (6912)</sp-tooltip>
+      <sp-tooltip placement="top" variant="info" style="width: 100px;">Export *.scr (6912)</sp-tooltip>
     </sp-action-button>
 
   </div>

--- a/main.js
+++ b/main.js
@@ -477,8 +477,31 @@ document.addEventListener("DOMContentLoaded", () => {
     setSliderDragging,
     notifySliderChange,
     setBrightMode,
-    setFlashEnabled,
-    saveSCR, // ← функція експорту
+  setFlashEnabled,
+  saveSCR, // ← функція експорту
+  });
+
+  // Tooltip handling: show after 1s, hide after 5s
+  document.querySelectorAll('.tooltip').forEach(btn => {
+    const tip = btn.querySelector('sp-tooltip');
+    if (!tip) return;
+    tip.removeAttribute('open');
+    let showT, hideT;
+    const cancel = () => {
+      clearTimeout(showT);
+      clearTimeout(hideT);
+      tip.removeAttribute('open');
+    };
+    btn.addEventListener('mouseenter', () => {
+      clearTimeout(showT);
+      clearTimeout(hideT);
+      showT = setTimeout(() => {
+        tip.setAttribute('open', '');
+        hideT = setTimeout(cancel, 5000);
+      }, 1000);
+    });
+    btn.addEventListener('mouseleave', cancel);
+    btn.addEventListener('click', cancel);
   });
 
   // Initial update

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -94,9 +94,12 @@ function setupControls({
   }
   updateBrightUI();
   if (typeof settings.flashEnabled === 'boolean' && flashChk) {
-    flashChk.checked = settings.flashEnabled;
-    setFlashEnabled(flashChk.checked);
+    flashChk.dataset.state = settings.flashEnabled ? 'on' : 'off';
+    setFlashEnabled(settings.flashEnabled);
+  } else if (flashChk && !flashChk.dataset.state) {
+    flashChk.dataset.state = 'off';
   }
+  updateFlashUI();
 
   // Синхронізуємо selectedAlg у main.js з UI після відновлення
   if (selAlg) setAlgorithm(selAlg.value);
@@ -112,6 +115,15 @@ function setupControls({
     if (autoIcon) autoIcon.classList.toggle('hidden', mode !== 'auto');
   }
 
+  function updateFlashUI() {
+    if (!flashChk) return;
+    const state = flashChk.dataset.state === 'on';
+    const onIcon = document.getElementById('flashOn');
+    const offIcon = document.getElementById('flashOff');
+    if (onIcon) onIcon.classList.toggle('hidden', !state);
+    if (offIcon) offIcon.classList.toggle('hidden', state);
+  }
+
 
   // Helper to update zoom label and preview
   function updateZoomLabelAndPreview() {
@@ -123,7 +135,7 @@ function setupControls({
       systemScale: getSystemScale(),
       ditherAlg: selAlg?.value,
       brightMode: brightSel?.dataset.mode,
-      flashEnabled: flashChk?.checked
+      flashEnabled: flashChk?.dataset.state === 'on'
     });
     updatePreview();
   }
@@ -137,7 +149,7 @@ function setupControls({
       zoomPreview: getZoom(),
       systemScale: getSystemScale(),
       brightMode: brightSel?.dataset.mode,
-      flashEnabled: flashChk?.checked
+      flashEnabled: flashChk?.dataset.state === 'on'
     });
     updatePreview();
   });
@@ -157,16 +169,19 @@ function setupControls({
       zoomPreview: getZoom(),
       systemScale: getSystemScale(),
       ditherAlg: selAlg?.value,
-      flashEnabled: flashChk?.checked
+      flashEnabled: flashChk?.dataset.state === 'on'
     });
     updatePreview();
   });
 
-  flashChk?.addEventListener("change", () => {
-    setFlashEnabled(flashChk.checked);
+  flashChk?.addEventListener("click", () => {
+    const next = flashChk.dataset.state === 'on' ? 'off' : 'on';
+    flashChk.dataset.state = next;
+    setFlashEnabled(next === 'on');
+    updateFlashUI();
     saveSettings({
       ...loadSettings(),
-      flashEnabled: flashChk.checked,
+      flashEnabled: next === 'on',
       zoomPreview: getZoom(),
       systemScale: getSystemScale(),
       ditherAlg: selAlg?.value,
@@ -222,7 +237,7 @@ function setupControls({
       zoomPreview: getZoom(),
       ditherAlg: selAlg?.value,
       brightMode: brightSel?.dataset.mode,
-      flashEnabled: flashChk?.checked
+      flashEnabled: flashChk?.dataset.state === 'on'
     });
     updatePreview();
   });
@@ -238,7 +253,7 @@ function setupControls({
         // Отримуємо RGBA через утиліту
         const { rgba } = await getRgbaPixels(imaging, { left: 0, top: 0, width: W, height: H }, false);
         let flashRgba = null;
-        if (flashChk?.checked) {
+        if (flashChk?.dataset.state === 'on') {
           let flashLayer = await ensureFlashLayer(d, imaging);
           try {
             const fr = await getRgbaPixels(imaging, { left: 0, top: 0, width: W, height: H, layerID: flashLayer.id }, false);
@@ -336,7 +351,7 @@ function setupControls({
           zoomPreview: getZoom(),
           ditherAlg: selAlg?.value,
           brightMode: brightSel?.dataset.mode,
-          flashEnabled: flashChk?.checked
+          flashEnabled: flashChk?.dataset.state === 'on'
         });
         updatePreview();
       }


### PR DESCRIPTION
## Summary
- enable tooltips with delayed appearance and timed hiding
- replace Flash switch with an icon button
- update UI logic for flash toggle button

## Testing
- `node tests/bright.test.js`
- `node tests/indexed.test.js`
- `node tests/scr.test.js`
- `node tests/bitdepth16.test.js` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_687a21bd2bd883339402f6eb65e1b01c