### PR TITLE
Handle 16-bit docs

### DIFF
--- a/main.js
+++ b/main.js
@@ -320,13 +320,14 @@ async function updatePreview(cacheOnly = false) {
       const docW = Math.round(+d.width),
             docH = Math.round(+d.height);
       const modeStr = String(d.mode || "").toLowerCase();
-      const bits = d.bitsPerChannel;
+      const bitStr = String(d.bitsPerChannel);
+      const bits = /16/.test(bitStr) ? 16 : 8;
 
       invalid = docW % 8 ||
         docH % 8 ||
         docW > 512 ||
         docH > 384 ||
-        !/(8|16)/.test(bits) || // supports 8-bit and 16-bit
+        !/(8|16)/.test(bitStr) || // supports 8-bit and 16-bit
         !/rgb/.test(modeStr);
 
       const formatChanged =

--- a/tests/bitdepth16.test.js
+++ b/tests/bitdepth16.test.js
@@ -1,20 +1,24 @@
 const assert = require('assert');
-const { convertTo8BitRgba } = require('../utils/utils');
+const { convertTo8BitRgba, convertTo16BitRgba } = require('../utils/utils');
 
 // RGBA input in 16 bits per channel
 const dataRgba16 = new Uint16Array([
-  65535, 32768, 0, 65535, // pixel 0
-  0, 32768, 65535, 0      // pixel 1
+  32768, 16384, 0, 65535, // pixel 0
+  0, 16384, 32768, 0      // pixel 1
 ]);
 const out1 = convertTo8BitRgba(dataRgba16, 2);
 assert.deepStrictEqual(Array.from(out1), [255, 128, 0, 255, 0, 128, 255, 0]);
 
 // RGB input in 16 bits per channel
 const dataRgb16 = new Uint16Array([
-  0, 65535, 32768, // pixel 0
-  65535, 0, 0      // pixel 1
+  0, 32768, 16384, // pixel 0
+  32768, 0, 0      // pixel 1
 ]);
 const out2 = convertTo8BitRgba(dataRgb16, 2);
 assert.deepStrictEqual(Array.from(out2), [0, 255, 128, 255, 255, 0, 0, 255]);
+
+const back = convertTo16BitRgba(out1);
+const round = convertTo8BitRgba(back, 2);
+assert.deepStrictEqual(Array.from(round), Array.from(out1));
 
 console.log('Bit depth 16 conversion tests passed');

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -1,6 +1,6 @@
 // src/ui/controls.js
 const { app, imaging, core } = require("photoshop");
-const { getRgbaPixels, ensureFlashLayer } = require("../utils/utils");
+const { getRgbaPixels, ensureFlashLayer, convertTo16BitRgba } = require("../utils/utils");
 const { indexedToRgba } = require("../utils/indexed");
 
 function getDomElements() {
@@ -256,7 +256,10 @@ function setupControls({
         // Застосовуємо фільтр ZX
         const indexed = zxFilter(rgba, W, H, flashRgba);
         const outRgba = indexedToRgba(indexed, false);
-        const newData = await imaging.createImageDataFromBuffer(outRgba, {
+        const bitStr = String(d.bitsPerChannel);
+        const bits = /16/.test(bitStr) ? 16 : 8;
+        const outBuf = bits === 16 ? convertTo16BitRgba(outRgba) : outRgba;
+        const newData = await imaging.createImageDataFromBuffer(outBuf, {
           width: W,
           height: H,
           components: 4,


### PR DESCRIPTION
## Summary
- add conversion from 8-bit to 16-bit RGBA
- create FLASH layer data in document bit depth
- adapt Apply button to use 16-bit buffers when needed
- expand bit depth tests
- **fix** bit depth check to handle Photoshop's string `bitsPerChannel`

## Testing
- `node tests/bitdepth16.test.js`
- `node tests/bright.test.js`
- `node tests/color.test.js`
- `node tests/indexed.test.js > /tmp/indexed.log && tail -n 5 /tmp/indexed.log`
- `node tests/scr.test.js > /tmp/scr.log && tail -n 5 /tmp/scr.log`


------
https://chatgpt.com/codex/tasks/task_e_687a20384cfc83338c40de8245456140