### PR TITLE
Fix tooltip placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,9 +241,10 @@
       </sp-action-button>
     </label>
 
-    <sp-action-button class="tooltip" id="applyBtn" style="width: 99px;">Paste
+    <div class="tooltip-wrapper">
+      <sp-action-button class="tooltip" id="applyBtn" style="width: 99px;">Paste</sp-action-button>
       <sp-tooltip placement="top" variant="info" style="width: 100px;">Paste to new layer</sp-tooltip>
-    </sp-action-button>
+    </div>
 
     <label>
       Amount
@@ -285,23 +286,27 @@
       </sp-action-button>
     </label>
 
-    <sp-action-button class="tooltip" id="importBtn" icon-only>
-      <div slot="icon" style="fill: currentColor">
-        <svg width="18" height="18">
-          <path d="M13.9,6c0-.41-.34-.75-.75-.75s-.75.34-.75.75.34.75.75.75.75-.34.75-.75ZM5.65,5.25c.41,0,.75.34.75.75s-.34.75-.75.75-.75-.34-.75-.75.34-.75.75-.75ZM11.65,6.75v-1.5h-4.5v1.5h4.5ZM17.65,1.5C17.65.67,16.98,0,16.15,0H2.65C1.82,0,1.15.67,1.15,1.5v9c0,.83.67,1.5,1.5,1.5h13.5c.83,0,1.5-.67,1.5-1.5V1.5ZM2.65,1.5h13.5v9h-1.61l-.17-1c-.12-.72-.75-1.25-1.48-1.25h-6.98c-.73,0-1.36.53-1.48,1.25l-.17,1h-1.61V1.5ZM13.01,10.5h-7.23l.12-.75h6.98l.12.75ZM9.4,15.84l-.75-.62-2.47-2.47-1.06,1.06,4.28,4.28,4.28-4.28-1.06-1.06-2.47,2.47-.75.62Z"/>
-        </svg>
-      </div>
+    <div class="tooltip-wrapper">
+      <sp-action-button class="tooltip" id="importBtn" icon-only>
+        <div slot="icon" style="fill: currentColor">
+          <svg width="18" height="18">
+            <path d="M13.9,6c0-.41-.34-.75-.75-.75s-.75.34-.75.75.34.75.75.75.75-.34.75-.75ZM5.65,5.25c.41,0,.75.34.75.75s-.34.75-.75.75-.75-.34-.75-.75.34-.75.75-.75ZM11.65,6.75v-1.5h-4.5v1.5h4.5ZM17.65,1.5C17.65.67,16.98,0,16.15,0H2.65C1.82,0,1.15.67,1.15,1.5v9c0,.83.67,1.5,1.5,1.5h13.5c.83,0,1.5-.67,1.5-1.5V1.5ZM2.65,1.5h13.5v9h-1.61l-.17-1c-.12-.72-.75-1.25-1.48-1.25h-6.98c-.73,0-1.36.53-1.48,1.25l-.17,1h-1.61V1.5ZM13.01,10.5h-7.23l.12-.75h6.98l.12.75ZM9.4,15.84l-.75-.62-2.47-2.47-1.06,1.06,4.28,4.28,4.28-4.28-1.06-1.06-2.47,2.47-.75.62Z"/>
+          </svg>
+        </div>
+      </sp-action-button>
       <sp-tooltip placement="top" variant="info" style="width: 100px;">Import *.scr (6912)</sp-tooltip>
-    </sp-action-button>
+    </div>
 
-    <sp-action-button class="tooltip" id="saveScrBtn" icon-only>
-      <div slot="icon" style="fill: currentColor">
-        <svg width="18" height="18">
-          <path d="M13.9,12c0-.41-.34-.75-.75-.75s-.75.34-.75.75.34.75.75.75.75-.34.75-.75ZM5.65,11.25c.41,0,.75.34.75.75s-.34.75-.75.75-.75-.34-.75-.75.34-.75.75-.75ZM11.65,12.75v-1.5h-4.5v1.5h4.5ZM17.65,7.5c0-.83-.67-1.5-1.5-1.5H2.65c-.83,0-1.5.67-1.5,1.5v9c0,.83.67,1.5,1.5,1.5h13.5c.83,0,1.5-.67,1.5-1.5V7.5ZM2.65,7.5h13.5v9h-1.61l-.17-1c-.12-.72-.75-1.25-1.48-1.25h-6.98c-.73,0-1.36.53-1.48,1.25l-.17,1h-1.61V7.5ZM13.01,16.5h-7.23l.12-.75h6.98l.12.75ZM9.4,3.09l-.75-.62L6.18,0l-1.06,1.06,4.28,4.28L13.68,1.06,12.62,0l-2.47,2.47-.75.62Z"/>
-        </svg>
-      </div>
+    <div class="tooltip-wrapper">
+      <sp-action-button class="tooltip" id="saveScrBtn" icon-only>
+        <div slot="icon" style="fill: currentColor">
+          <svg width="18" height="18">
+            <path d="M13.9,12c0-.41-.34-.75-.75-.75s-.75.34-.75.75.34.75.75.75.75-.34.75-.75ZM5.65,11.25c.41,0,.75.34.75.75s-.34.75-.75.75-.75-.34-.75-.75.34-.75.75-.75ZM11.65,12.75v-1.5h-4.5v1.5h4.5ZM17.65,7.5c0-.83-.67-1.5-1.5-1.5H2.65c-.83,0-1.5.67-1.5,1.5v9c0,.83.67,1.5,1.5,1.5h13.5c.83,0,1.5-.67,1.5-1.5V7.5ZM2.65,7.5h13.5v9h-1.61l-.17-1c-.12-.72-.75-1.25-1.48-1.25h-6.98c-.73,0-1.36.53-1.48,1.25l-.17,1h-1.61V7.5ZM13.01,16.5h-7.23l.12-.75h6.98l.12.75ZM9.4,3.09l-.75-.62L6.18,0l-1.06,1.06,4.28,4.28L13.68,1.06,12.62,0l-2.47,2.47-.75.62Z"/>
+          </svg>
+        </div>
+      </sp-action-button>
       <sp-tooltip placement="top" variant="info" style="width: 100px;">Export *.scr (6912)</sp-tooltip>
-    </sp-action-button>
+    </div>
 
   </div>
 

--- a/main.js
+++ b/main.js
@@ -452,7 +452,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Tooltip handling: show after 1s, hide after 5s
   document.querySelectorAll('.tooltip').forEach(btn => {
-    const tip = btn.querySelector('sp-tooltip');
+    const tip = btn.querySelector('sp-tooltip') || btn.parentElement?.querySelector('sp-tooltip');
     if (!tip) return;
     tip.removeAttribute('open');
     let showT, hideT;


### PR DESCRIPTION
## Summary
- wrap tooltips outside action buttons so icons stay centered
- update tooltip JS handler to support wrapper

## Testing
- `node tests/bitdepth16.test.js && node tests/bright.test.js && node tests/color.test.js && node tests/flash.test.js && node tests/indexed.test.js && node tests/scr.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687a49ab97248333b9d41a889b844ed9