### PR TITLE
Add SCR import feature

### DIFF
--- a/tests/scr.test.js
+++ b/tests/scr.test.js
@@ -2,7 +2,7 @@
 // Run with: node tests/scr.test.js
 
 const assert = require('assert');
-const { encodeTiles } = require('../utils/scr');
+const { encodeTiles, decodeScr } = require('../utils/scr');
 
 function makeIndexed(W, H, ink = 1, paper = 0) {
   const pixels = new Uint8Array(W * H);
@@ -13,33 +13,13 @@ function makeIndexed(W, H, ink = 1, paper = 0) {
   return { pixels, attrs, width: W, height: H };
 }
 
-function decode(scr) {
-  const pixels = new Uint8Array(256 * 192);
-  for (let y = 0; y < 192; y++) {
-    for (let xb = 0; xb < 32; xb++) {
-      const addr = ((y & 0xC0) << 5) | ((y & 0x38) << 2) | ((y & 0x07) << 8) | xb;
-      const byte = scr[addr];
-      for (let bit = 0; bit < 8; bit++) {
-        const x = xb * 8 + bit;
-        pixels[y * 256 + x] = (byte >> (7 - bit)) & 1;
-      }
-    }
-  }
-  const attrs = new Uint8Array(32 * 24);
-  for (let by = 0; by < 24; by++) {
-    for (let bx = 0; bx < 32; bx++) {
-      attrs[by * 32 + bx] = scr[6144 + by * 32 + bx];
-    }
-  }
-  return { pixels, attrs };
-}
 
 // Case 1: 64x64
 (() => {
   const idx = makeIndexed(64, 64);
   const tiles = encodeTiles(idx);
   assert.strictEqual(tiles.length, 1);
-  const d = decode(tiles[0].bytes);
+  const d = decodeScr(tiles[0].bytes);
   for (let y = 0; y < 192; y++) {
     for (let x = 0; x < 256; x++) {
       const val = d.pixels[y * 256 + x];
@@ -50,8 +30,9 @@ function decode(scr) {
   for (let by = 0; by < 24; by++) {
     for (let bx = 0; bx < 32; bx++) {
       const a = d.attrs[by * 32 + bx];
-      if (by < 8 && bx < 8) assert.strictEqual(a, 1);
-      else assert.strictEqual(a, 7);
+      const val = ((a.flash ? 1 : 0) << 7) | ((a.bright ? 1 : 0) << 6) | ((a.paper & 7) << 3) | (a.ink & 7);
+      if (by < 8 && bx < 8) assert.strictEqual(val, 1);
+      else assert.strictEqual(val, 7);
     }
   }
 })();
@@ -61,9 +42,12 @@ function decode(scr) {
   const idx = makeIndexed(256, 192, 2);
   const tiles = encodeTiles(idx);
   assert.strictEqual(tiles.length, 1);
-  const d = decode(tiles[0].bytes);
-  for (const v of d.pixels) assert.strictEqual(v, 1);
-  for (const a of d.attrs) assert.strictEqual(a, 2);
+  const d = decodeScr(tiles[0].bytes);
+  for (const v of d.pixels) assert.strictEqual(v, 2);
+  for (const a of d.attrs) {
+    const val = ((a.flash ? 1 : 0) << 7) | ((a.bright ? 1 : 0) << 6) | ((a.paper & 7) << 3) | (a.ink & 7);
+    assert.strictEqual(val, 2);
+  }
 })();
 
 // Case 3: 512x64 -> two tiles
@@ -72,7 +56,7 @@ function decode(scr) {
   const tiles = encodeTiles(idx);
   assert.strictEqual(tiles.length, 2);
   tiles.forEach((t, i) => {
-    const d = decode(t.bytes);
+    const d = decodeScr(t.bytes);
     for (let y = 0; y < 192; y++) {
       for (let x = 0; x < 256; x++) {
         const val = d.pixels[y * 256 + x];
@@ -89,7 +73,7 @@ function decode(scr) {
   const tiles = encodeTiles(idx);
   assert.strictEqual(tiles.length, 4);
   tiles.forEach(t => {
-    const d = decode(t.bytes);
+    const d = decodeScr(t.bytes);
     for (let y = 0; y < 192; y++) {
       for (let x = 0; x < 256; x++) {
         const inDocX = t.tx * 256 + x < 300;
@@ -107,11 +91,17 @@ function decode(scr) {
   const idx = makeIndexed(8, 8, 3, 3);
   const tiles = encodeTiles(idx);
   assert.strictEqual(tiles.length, 1);
-  const d = decode(tiles[0].bytes);
-  for (const val of d.pixels) assert.strictEqual(val, 0);
+  const d = decodeScr(tiles[0].bytes);
+  for (let i = 0; i < d.pixels.length; i++) {
+    const val = d.pixels[i];
+    const x = i % 256;
+    const y = Math.floor(i / 256);
+    if (x < 8 && y < 8) assert.strictEqual(val, 3); else assert.strictEqual(val, 0);
+  }
   for (let i = 0; i < d.attrs.length; i++) {
     const a = d.attrs[i];
-    if (i === 0) assert.strictEqual(a, 28); else assert.strictEqual(a, 7);
+    const val = ((a.flash ? 1 : 0) << 7) | ((a.bright ? 1 : 0) << 6) | ((a.paper & 7) << 3) | (a.ink & 7);
+    if (i === 0) assert.strictEqual(val, 28); else assert.strictEqual(val, 7);
   }
 })();
 
@@ -131,17 +121,19 @@ function decode(scr) {
   const idx = { pixels, attrs, width: W, height: H };
   const tiles = encodeTiles(idx);
   assert.strictEqual(tiles.length, 1);
-  const d = decode(tiles[0].bytes);
+  const d = decodeScr(tiles[0].bytes);
   for (let y = 0; y < 8; y++) {
     for (let x = 0; x < 16; x++) {
       const val = d.pixels[y * 256 + x];
-      assert.strictEqual(val, 1);
+      if (x < 8) assert.strictEqual(val, 0); else assert.strictEqual(val, 1);
     }
   }
   const a0 = d.attrs[0];
   const a1 = d.attrs[1];
-  assert.strictEqual(a0, 0);
-  assert.strictEqual(a1, 1);
+  const v0 = ((a0.flash ? 1 : 0) << 7) | ((a0.bright ? 1 : 0) << 6) | ((a0.paper & 7) << 3) | (a0.ink & 7);
+  const v1 = ((a1.flash ? 1 : 0) << 7) | ((a1.bright ? 1 : 0) << 6) | ((a1.paper & 7) << 3) | (a1.ink & 7);
+  assert.strictEqual(v0, 0);
+  assert.strictEqual(v1, 1);
 })();
 
 console.log('SCR tiling tests passed');

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -17,6 +17,7 @@ function getDomElements() {
     brightSel: document.getElementById("brightModeSel"),
     flashChk: document.getElementById("flashChk"),
     saveScrBtn: document.getElementById("saveScrBtn"),
+    importBtn: document.getElementById("importBtn"),
     // Preferences dialog elements
     btnPrefs: document.getElementById("openPrefs"),
     prefsDialog: document.getElementById("prefsDialog"),
@@ -53,6 +54,7 @@ function setupControls({
   setBrightMode,
   setFlashEnabled,
   saveSCR,
+  importSCR,
 }) {
   const {
     btnDown,
@@ -67,6 +69,7 @@ function setupControls({
     brightSel,
     flashChk,
     saveScrBtn,
+    importBtn,
     // Preferences dialog elements
     btnPrefs,
     prefsDialog,
@@ -193,6 +196,11 @@ function setupControls({
   // Save SCR button
   saveScrBtn?.addEventListener("click", () => {
     saveSCR().catch(console.error);
+  });
+
+  // Import SCR button
+  importBtn?.addEventListener("click", () => {
+    importSCR().catch(console.error);
   });
 
   // Strength slider

--- a/utils/scr.js
+++ b/utils/scr.js
@@ -108,4 +108,37 @@ function encodeTiles(indexed) {
   return tiles;
 }
 
-module.exports = { encodeTile, encodeTiles };
+function decodeScr(scr) {
+  if (!scr || scr.length !== 6912) throw new Error('Invalid SCR buffer');
+  const W = 256;
+  const H = 192;
+  const pixels = new Uint8Array(W * H);
+  const attrs = new Array(32 * 24);
+  for (let by = 0; by < 24; by++) {
+    for (let bx = 0; bx < 32; bx++) {
+      const a = scr[6144 + by * 32 + bx];
+      attrs[by * 32 + bx] = {
+        flash: (a >> 7) & 1,
+        bright: (a >> 6) & 1,
+        paper: (a >> 3) & 7,
+        ink: a & 7,
+      };
+    }
+  }
+  for (let y = 0; y < H; y++) {
+    const by = y >> 3;
+    for (let xb = 0; xb < 32; xb++) {
+      const addr = ((y & 0xC0) << 5) | ((y & 0x38) << 2) | ((y & 0x07) << 8) | xb;
+      const byte = scr[addr];
+      const attr = attrs[by * 32 + xb];
+      for (let bit = 0; bit < 8; bit++) {
+        const x = xb * 8 + bit;
+        const bitVal = (byte >> (7 - bit)) & 1;
+        pixels[y * W + x] = bitVal ? attr.ink : attr.paper;
+      }
+    }
+  }
+  return { pixels, attrs, width: W, height: H };
+}
+
+module.exports = { encodeTile, encodeTiles, decodeScr };


### PR DESCRIPTION
## Summary
- implement `decodeScr` helper to parse ZX .scr files
- add `importSCR` function and integrate with UI
- wire new Import button in controls
- update SCR tests for decode changes

## Testing
- `node tests/color.test.js && node tests/bitdepth16.test.js && node tests/bright.test.js && node tests/flash.test.js && node tests/indexed.test.js && node tests/scr.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687a5c4e92288333812365cebd02fcd8