### PR TITLE
Implement uniform block BFS normalization

### DIFF
--- a/tests/scr.test.js
+++ b/tests/scr.test.js
@@ -144,4 +144,28 @@ function decode(scr) {
   assert.strictEqual(a1, 1);
 })();
 
+// Case 7: propagation through multiple uniform blocks
+(() => {
+  const W = 24; const H = 8;
+  const pixels = new Uint8Array(W * H);
+  for (let y = 0; y < 8; y++) {
+    for (let x = 0; x < 8; x++) pixels[y * W + x] = 1;
+  }
+  const attrs = [
+    { ink: 1, paper: 0, bright: 0, flash: 0 },
+    { ink: 0, paper: 0, bright: 0, flash: 0 },
+    { ink: 0, paper: 0, bright: 0, flash: 0 },
+  ];
+  const idx = { pixels, attrs, width: W, height: H };
+  const tiles = encodeTiles(idx);
+  assert.strictEqual(tiles.length, 1);
+  const d = decode(tiles[0].bytes);
+  for (let y = 0; y < 8; y++) {
+    for (let x = 0; x < 24; x++) {
+      const val = d.pixels[y * 256 + x];
+      assert.strictEqual(val, 1);
+    }
+  }
+})();
+
 console.log('SCR tiling tests passed');

--- a/utils/indexed.js
+++ b/utils/indexed.js
@@ -228,5 +228,6 @@ module.exports = {
   ZX_FULL,
   rgbToIndex,
   applyFlashAttrs,
+  _isImageDark,
   optimizeAttributes,
 };

--- a/utils/scr.js
+++ b/utils/scr.js
@@ -1,13 +1,123 @@
 // utils/scr.js
 // Encoding ZX Spectrum SCR files with tiling support
 
-// relative positions of neighbouring blocks used when resolving uniform blocks
+// relative positions of neighbouring blocks (no diagonals)
 const NEIGHBOR_OFFSETS = [
-  [-1, 0], [1, 0], [0, -1], [0, 1],
-  [-1, -1], [1, -1], [-1, 1], [1, 1]
+  [-1, 0], [1, 0], [0, -1], [0, 1]
 ];
 
-function encodeTile(indexed, tx = 0, ty = 0) {
+// Determine majority fill for uniform blocks using BFS queue
+function computeFillBytes(indexed, preferDarkInk = true) {
+  const { pixels, attrs, width: W, height: H } = indexed;
+  const cols = Math.ceil(W / 8);
+  const rows = Math.ceil(H / 8);
+  const total = cols * rows;
+  const fill = new Uint8Array(total); // 0x00 or 0xFF per block
+
+  const normal = new Set();
+  const uniform = new Set();
+
+  // normalize attributes and split blocks into normal/uniform
+  for (let by = 0; by < rows; by++) {
+    for (let bx = 0; bx < cols; bx++) {
+      const idx = by * cols + bx;
+      const attr = attrs[idx];
+      if (!attr) continue;
+      if (attr.ink !== attr.paper) {
+        if ((preferDarkInk && attr.ink > attr.paper) || (!preferDarkInk && attr.ink < attr.paper)) {
+          const t = attr.ink; attr.ink = attr.paper; attr.paper = t;
+        }
+        normal.add(idx);
+      } else {
+        uniform.add(idx);
+      }
+    }
+  }
+
+  if (!uniform.size) return fill;
+
+  const isDark = _isImageDark(indexed);
+
+  const queued = new Set();
+  const processed = new Set();
+  const queues = [[], [], [], [], []];
+
+  function inBounds(bx, by) {
+    return bx >= 0 && bx < cols && by >= 0 && by < rows;
+  }
+
+  function countNormal(idx) {
+    const bx = idx % cols; const by = Math.floor(idx / cols);
+    let c = 0;
+    for (const [dx, dy] of NEIGHBOR_OFFSETS) {
+      const nbx = bx + dx; const nby = by + dy;
+      if (!inBounds(nbx, nby)) continue;
+      if (normal.has(nby * cols + nbx)) c++;
+    }
+    return c;
+  }
+
+  function enqueue(idx) {
+    if (queued.has(idx) || processed.has(idx) || !uniform.has(idx)) return;
+    const c = countNormal(idx);
+    if (c > 0) { queues[c].push(idx); queued.add(idx); }
+  }
+
+  for (const idx of uniform) enqueue(idx);
+
+  function edgeCounts(idx) {
+    const bx = idx % cols; const by = Math.floor(idx / cols);
+    let ones = 0, zeros = 0;
+    for (const [dx, dy] of NEIGHBOR_OFFSETS) {
+      const nbx = bx + dx; const nby = by + dy;
+      if (!inBounds(nbx, nby)) continue;
+      const nIdx = nby * cols + nbx;
+      if (!normal.has(nIdx)) continue;
+      const nAttr = attrs[nIdx];
+      for (let s = 0; s < 8; s++) {
+        let x, y;
+        if (dx === -1) { x = nbx * 8 + 7; y = by * 8 + s; }
+        else if (dx === 1) { x = nbx * 8; y = by * 8 + s; }
+        else if (dy === -1) { x = bx * 8 + s; y = nby * 8 + 7; }
+        else { x = bx * 8 + s; y = nby * 8; }
+        if (x >= W || y >= H) continue;
+        const val = pixels[y * W + x];
+        if (val === nAttr.ink) ones++; else zeros++;
+      }
+    }
+    return { ones, zeros };
+  }
+
+  while (queues.some(q => q.length)) {
+    let lvl = 4;
+    while (lvl > 0 && queues[lvl].length === 0) lvl--;
+    if (lvl === 0) break;
+    const idx = queues[lvl].shift();
+    queued.delete(idx);
+    if (processed.has(idx)) continue;
+    const { ones, zeros } = edgeCounts(idx);
+    let byte;
+    if (ones === zeros) byte = isDark ? 0x00 : 0xFF;
+    else byte = ones > zeros ? 0xFF : 0x00;
+    fill[idx] = byte;
+    normal.add(idx);
+    processed.add(idx);
+    for (const [dx, dy] of NEIGHBOR_OFFSETS) {
+      const nbx = (idx % cols) + dx; const nby = Math.floor(idx / cols) + dy;
+      if (!inBounds(nbx, nby)) continue;
+      enqueue(nby * cols + nbx);
+    }
+  }
+
+  // any remaining blocks default by overall brightness
+  for (const idx of uniform) {
+    if (!processed.has(idx)) fill[idx] = isDark ? 0x00 : 0xFF;
+  }
+
+  return fill;
+}
+
+function encodeTile(indexed, fillMap, tx = 0, ty = 0) {
   const { pixels, attrs, width: W, height: H } = indexed;
   const wBlocks = Math.ceil(W / 8);
   const hBlocks = Math.ceil(H / 8);
@@ -27,32 +137,7 @@ function encodeTile(indexed, tx = 0, ty = 0) {
       const aIdx = (startBy + by) * wBlocks + (startBx + bx);
       const attr = attrs[aIdx] || { ink: 7, paper: 0, bright: 0, flash: 0 };
 
-      let fillByte = 0;
-      // if block uses only one color we approximate pixels using neighbours
-      if (attr.ink === attr.paper) {
-        let ones = 0;
-        let zeros = 0;
-        for (const [dx, dy] of NEIGHBOR_OFFSETS) {
-          const nbx = startBx + bx + dx;
-          const nby = startBy + by + dy;
-          if (nbx < 0 || nbx >= wBlocks || nby < 0 || nby >= hBlocks) continue;
-          const nAttr = attrs[nby * wBlocks + nbx];
-          if (!nAttr || nAttr.ink === nAttr.paper) continue;
-          for (let sy = 0; sy < 8; sy++) {
-            const y = nby * 8 + sy;
-            if (y >= H) continue;
-            for (let sx = 0; sx < 8; sx++) {
-              const x = nbx * 8 + sx;
-              if (x >= W) continue;
-              const idx = pixels[y * W + x];
-              if (idx === nAttr.ink) ones++; else zeros++;
-            }
-          }
-        }
-        fillByte = ones > zeros ? 0xFF : 0x00;
-      }
-      
-      fillByte = 0xFF; //тимчасовий заповнювач для тестування 
+      const fillByte = attr.ink === attr.paper ? fillMap[aIdx] : 0;
       
       for (let dy = 0; dy < 8; dy++) {
         const y = by * 8 + dy;
@@ -86,10 +171,10 @@ function encodeTile(indexed, tx = 0, ty = 0) {
   return scr;
 }
 
-const { optimizeAttributes } = require('./indexed');
+const { optimizeAttributes, _isImageDark } = require('./indexed');
 
 // Split large images into 256x192 tiles encoded as individual .scr buffers
-function encodeTiles(indexed) {
+function encodeTiles(indexed, preferDarkInk = false) {
   // tweak attributes globally before tiling (only handle fully uniform case)
   if (indexed.attrs.every(a => a.ink === a.paper)) {
     const paper = indexed.attrs[0].paper & 7;
@@ -97,15 +182,16 @@ function encodeTiles(indexed) {
     for (const attr of indexed.attrs) attr.ink = complement;
     indexed.pixels.fill(paper);
   }
+  const fillMap = computeFillBytes(indexed, preferDarkInk);
   const tilesX = Math.ceil(indexed.width / 256);
   const tilesY = Math.ceil(indexed.height / 192);
   const tiles = [];
   for (let ty = 0; ty < tilesY; ty++) {
     for (let tx = 0; tx < tilesX; tx++) {
-      tiles.push({ tx, ty, bytes: encodeTile(indexed, tx, ty) });
+      tiles.push({ tx, ty, bytes: encodeTile(indexed, fillMap, tx, ty) });
     }
   }
   return tiles;
 }
 
-module.exports = { encodeTile, encodeTiles };
+module.exports = { encodeTile, encodeTiles, computeFillBytes };


### PR DESCRIPTION
## Summary
- normalize attribute orientation per block and compute fill bytes via BFS
- export `_isImageDark` utility
- add new propagation test for SCR encoding

## Testing
- `node tests/color.test.js`
- `node tests/indexed.test.js`
- `node tests/bright.test.js`
- `node tests/flash.test.js`
- `node tests/bitdepth16.test.js`
- `node tests/scr.test.js`


------
https://chatgpt.com/codex/tasks/task_e_687a5a99f0708333a078906732a6bd49